### PR TITLE
Use a caching writer to avoid overwriting identical files

### DIFF
--- a/modello-core/src/main/java/org/codehaus/modello/plugin/AbstractModelloGenerator.java
+++ b/modello-core/src/main/java/org/codehaus/modello/plugin/AbstractModelloGenerator.java
@@ -23,6 +23,9 @@ package org.codehaus.modello.plugin;
  */
 
 import java.io.File;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -287,4 +290,11 @@ public abstract class AbstractModelloGenerator
     {
         return buildContext;
     }
+
+    protected Writer newWriter( Path path )
+    {
+        Charset charset = getEncoding() != null ? Charset.forName( getEncoding() ) : Charset.defaultCharset();
+        return new CachingWriter( getBuildContext(), path, charset );
+    }
+
 }

--- a/modello-core/src/main/java/org/codehaus/modello/plugin/CachingWriter.java
+++ b/modello-core/src/main/java/org/codehaus/modello/plugin/CachingWriter.java
@@ -1,0 +1,55 @@
+package org.codehaus.modello.plugin;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+public class CachingWriter extends StringWriter
+{
+    private final BuildContext buildContext;
+    private final Path path;
+    private final Charset charset;
+
+    public CachingWriter( BuildContext buildContext, Path path, Charset charset )
+    {
+        this.buildContext = buildContext;
+        this.path = Objects.requireNonNull( path );
+        this.charset = Objects.requireNonNull( charset );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        String str = getBuffer().toString();
+        if ( Files.exists( path ) )
+        {
+            String old = readString( path, charset );
+            if ( str.equals( old ) )
+            {
+                return;
+            }
+        }
+        writeString( path, str, charset );
+        if ( buildContext != null )
+        {
+            buildContext.refresh( path.toFile() );
+        }
+    }
+
+    private static String readString( Path path, Charset charset ) throws IOException
+    {
+        byte[] ba = Files.readAllBytes( path );
+        return new String( ba, charset );
+    }
+
+    private static void writeString( Path path, String str, Charset charset ) throws IOException
+    {
+        byte[] ba = str.getBytes( charset );
+        Files.write( path, ba );
+    }
+}

--- a/modello-plugins/modello-plugin-java/src/main/java/org/codehaus/modello/plugin/java/AbstractJavaModelloGenerator.java
+++ b/modello-plugins/modello-plugin-java/src/main/java/org/codehaus/modello/plugin/java/AbstractJavaModelloGenerator.java
@@ -24,8 +24,9 @@ package org.codehaus.modello.plugin.java;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -47,6 +48,7 @@ import org.codehaus.modello.model.ModelField;
 import org.codehaus.modello.model.ModelInterface;
 import org.codehaus.modello.model.ModelType;
 import org.codehaus.modello.plugin.AbstractModelloGenerator;
+import org.codehaus.modello.plugin.CachingWriter;
 import org.codehaus.modello.plugin.java.javasource.JClass;
 import org.codehaus.modello.plugin.java.javasource.JComment;
 import org.codehaus.modello.plugin.java.javasource.JInterface;
@@ -57,7 +59,6 @@ import org.codehaus.modello.plugin.java.metadata.JavaFieldMetadata;
 import org.codehaus.modello.plugin.java.metadata.JavaModelMetadata;
 import org.codehaus.modello.plugin.model.ModelClassMetadata;
 import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.WriterFactory;
 
 /**
  * AbstractJavaModelloGenerator - similar in scope to {@link AbstractModelloGenerator} but with features that
@@ -102,12 +103,7 @@ public abstract class AbstractJavaModelloGenerator
             f.getParentFile().mkdirs();
         }
 
-        OutputStream os = getBuildContext().newFileOutputStream( f );
-
-        Writer writer = ( getEncoding() == null ) ? WriterFactory.newPlatformWriter( os )
-                        : WriterFactory.newWriter( os, getEncoding() );
-
-        return new JSourceWriter( writer );
+        return new JSourceWriter( newWriter( f.toPath() ) );
     }
 
     private JComment getHeaderComment()

--- a/modello-plugins/modello-plugin-jsonschema/src/main/java/org/codehaus/modello/plugin/jsonschema/JsonSchemaGenerator.java
+++ b/modello-plugins/modello-plugin-jsonschema/src/main/java/org/codehaus/modello/plugin/jsonschema/JsonSchemaGenerator.java
@@ -107,7 +107,7 @@ public final class JsonSchemaGenerator
                                   .enable( JsonWriteFeature.QUOTE_FIELD_NAMES.mappedFeature() )
                                   .enable( JsonWriteFeature.QUOTE_FIELD_NAMES.mappedFeature() )
                                   .disable( JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS.mappedFeature() )
-                                  .createGenerator( schemaFile, JsonEncoding.UTF8 );
+                                  .createGenerator( newWriter( schemaFile.toPath() ) );
 
         generator.useDefaultPrettyPrinter();
 


### PR DESCRIPTION
@rfscholte 
This can improve build time quite substantially. For example the maven re-build (no clean, no tests) goes from 32.8s down to 28.8s on my laptop.  So that's an easy 12% benefit.
I'm going to submit a PR for the maven-resource-plugin too.  