### PR TITLE
Fix javaSource default value

### DIFF
--- a/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojo.java
+++ b/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojo.java
@@ -53,7 +53,7 @@ public abstract class AbstractModelloSourceGeneratorMojo
      * @since 1.0
      */
     @Parameter( defaultValue = "${maven.compiler.source}" )
-    private Integer javaSource;
+    private String javaSource;
 
     /**
      * Generate DOM content as plexus-utils <code>Xpp3Dom</code> objects instead of <code>org.w3c.dom.Element</code>.
@@ -90,7 +90,11 @@ public abstract class AbstractModelloSourceGeneratorMojo
 
         if ( javaSource != null )
         {
-            parameters.setProperty( ModelloParameterConstants.OUTPUT_JAVA_SOURCE, Integer.toString( javaSource ) );
+            if ( javaSource.startsWith( "1." ) )
+            {
+                javaSource = javaSource.substring( "1.".length() );
+            }
+            parameters.setProperty( ModelloParameterConstants.OUTPUT_JAVA_SOURCE, javaSource );
         }
 
         parameters.setProperty( ModelloParameterConstants.DOM_AS_XPP3, Boolean.toString( domAsXpp3 ) );


### PR DESCRIPTION
The default value is `${maven.compiler.source}` which can be 1.8 for example.
The is a big incompatibility issue which happens for example if you upgrade modello in the maven build to 2.0.0-SNAPSHOT.

@rfscholte this is a follow-up / fix to https://github.com/codehaus-plexus/modello/commit/08152b14bb44867c038e52fc957c46ec1906668e