### PR TITLE
Make the Xpp3Reader#read(XmlPullParser, boolean strict) public

### DIFF
--- a/modello-plugins/modello-plugin-xpp3/src/main/java/org/codehaus/modello/plugin/xpp3/Xpp3ReaderGenerator.java
+++ b/modello-plugins/modello-plugin-xpp3/src/main/java/org/codehaus/modello/plugin/xpp3/Xpp3ReaderGenerator.java
@@ -148,7 +148,6 @@ public class Xpp3ReaderGenerator
         // ----------------------------------------------------------------------
 
         JMethod unmarshall = new JMethod( readerMethodName, new JClass( className ), null );
-        unmarshall.getModifiers().makePrivate();
 
         unmarshall.addParameter( new JParameter( new JClass( "XmlPullParser" ), "parser" ) );
         unmarshall.addParameter( new JParameter( JClass.BOOLEAN, "strict" ) );


### PR DESCRIPTION
This would avoid using reflection in maven-model-builder:
  https://github.com/apache/maven/blob/master/maven-model-builder/src/main/java/org/apache/maven/model/io/DefaultModelReader.java#L178-L203