### PR TITLE
add velocityBasedir to select where to load (shared) .vm from

### DIFF
--- a/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/ModelloVelocityMojo.java
+++ b/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/ModelloVelocityMojo.java
@@ -61,19 +61,26 @@ public class ModelloVelocityMojo
     /**
      * The output directory of the generated files.
      */
-    @Parameter( defaultValue = "${project.build.directory}/generated-sources/modello", required = true )
+    @Parameter( defaultValue = "${project.build.directory}/generated-sources/modello" )
     private File outputDirectory;
 
     /**
-     * A list of template paths to be run against the loaded modello model.
+     * The directory where Velocity templates are looked for.
+     */
+    @Parameter( defaultValue = "${project.basedir}" )
+    private File velocityBasedir;
+
+    /**
+     * A list of template paths to be run against the loaded Modello model.
      * Those are {@code .vm} files as described in the
-     * <a href="https://velocity.apache.org/engine/devel/user-guide.html">Velocity Users Guide</a>.
+     * <a href="https://velocity.apache.org/engine/devel/user-guide.html">Velocity Users Guide</a>
+     * relative to {@code velocityBasedir}.
      */
     @Parameter
     private List<String> templates;
 
     /**
-     * A list of parameters using the syntax {@code key=value}.
+     * A list of parameters, using the syntax {@code key=value}.
      * Those parameters will be made accessible to the templates.
      */
     @Parameter
@@ -87,13 +94,15 @@ public class ModelloVelocityMojo
     protected void customizeParameters( Properties parameters )
     {
         super.customizeParameters( parameters );
-        Map<String, String> params = this.params != null ? this.params.stream().collect( Collectors.toMap(
-                s -> s.substring( 0, s.indexOf( '=' ) ), s -> s.substring( s.indexOf( '=' ) + 1 )
-        ) ) : Collections.emptyMap();
-        parameters.put( "basedir", Objects.requireNonNull( getBasedir(), "basedir is null" ) );
-        Path basedir = Paths.get( getBasedir() );
-        parameters.put( VelocityGenerator.VELOCITY_TEMPLATES, templates.stream()
-                        .collect( Collectors.joining( "," ) ) );
+
+        Map<String, String> params = this.params == null ? Collections.emptyMap()
+                : this.params.stream().collect( Collectors.toMap( s -> s.substring( 0, s.indexOf( '=' ) ),
+                                                                  s -> s.substring( s.indexOf( '=' ) + 1 ) ) );
+
+        parameters.put( VelocityGenerator.VELOCITY_BASEDIR, velocityBasedir.getAbsolutePath() );
+
+        parameters.put( VelocityGenerator.VELOCITY_TEMPLATES,
+                        templates.stream().collect( Collectors.joining( "," ) ) );
         parameters.put( VelocityGenerator.VELOCITY_PARAMETERS, params );
     }
 
@@ -102,13 +111,9 @@ public class ModelloVelocityMojo
         return true;
     }
 
+    @Override
     public File getOutputDirectory()
     {
         return outputDirectory;
-    }
-
-    public void setOutputDirectory( File outputDirectory )
-    {
-        this.outputDirectory = outputDirectory;
     }
 }

--- a/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/ModelloVelocityMojo.java
+++ b/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/ModelloVelocityMojo.java
@@ -65,12 +65,12 @@ public class ModelloVelocityMojo
     private File outputDirectory;
 
     /**
-     * A list of template files to be run against the loaded modello model.
+     * A list of template paths to be run against the loaded modello model.
      * Those are {@code .vm} files as described in the
      * <a href="https://velocity.apache.org/engine/devel/user-guide.html">Velocity Users Guide</a>.
      */
     @Parameter
-    private List<File> templates;
+    private List<String> templates;
 
     /**
      * A list of parameters using the syntax {@code key=value}.
@@ -93,9 +93,6 @@ public class ModelloVelocityMojo
         parameters.put( "basedir", Objects.requireNonNull( getBasedir(), "basedir is null" ) );
         Path basedir = Paths.get( getBasedir() );
         parameters.put( VelocityGenerator.VELOCITY_TEMPLATES, templates.stream()
-                        .map( File::toPath )
-                        .map( basedir::relativize )
-                        .map( Path::toString )
                         .collect( Collectors.joining( "," ) ) );
         parameters.put( VelocityGenerator.VELOCITY_PARAMETERS, params );
     }

--- a/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
+++ b/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
@@ -45,6 +45,8 @@ import org.codehaus.plexus.util.io.CachingWriter;
 public class VelocityGenerator
         extends AbstractModelloGenerator
 {
+    public static final String VELOCITY_BASEDIR = "modello.velocity.basedir";
+
     public static final String VELOCITY_TEMPLATES = "modello.velocity.templates";
 
     public static final String VELOCITY_PARAMETERS = "modello.velocity.parameters";
@@ -61,7 +63,7 @@ public class VelocityGenerator
             String output = getParameter( parameters, ModelloParameterConstants.OUTPUT_DIRECTORY );
 
             Properties props = new Properties();
-            props.put( "resource.loader.file.path", getParameter( parameters, "basedir" ) );
+            props.put( "resource.loader.file.path", getParameter( parameters, VELOCITY_BASEDIR ) );
             RuntimeInstance velocity = new RuntimeInstance();
             velocity.init( props );
 

--- a/modello-plugins/modello-plugin-velocity/src/site/xdoc/index.xml
+++ b/modello-plugins/modello-plugin-velocity/src/site/xdoc/index.xml
@@ -17,7 +17,7 @@
 
     <section name="Velocity Processing">
 
-      <p>The plugin is configured with a list of <code>template</code> files to evaluate.</p>
+      <p>The plugin is configured with a list of <code>template</code> files to evaluate, rfelative to <code>velocityBasedir</code> (which defaults to Maven's <code>${project.basedir}</code>).</p>
       <p>During template evaluation, <code>#MODELLO-VELOCITY#SAVE-OUTPUT-TO {relative path to file}</code> pseudo macro is available to send the rendered content to a file.</p>
       <p>The Velocity context contains some variables related to the Modello model context that you can use:
       <table>


### PR DESCRIPTION
useful for https://github.com/apache/maven/pull/949 because all generation code is in `.vm` files with Velocity plugin, then it's useful to be able to easily share them between multiple Maven modules instead of copy/pasting