### PR TITLE
Remove readonly flag from basedir: support .mdo from any location

### DIFF
--- a/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloGeneratorMojo.java
+++ b/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloGeneratorMojo.java
@@ -55,9 +55,9 @@ public abstract class AbstractModelloGeneratorMojo
     // ----------------------------------------------------------------------
 
     /**
-     * Base directory of the project.
+     * Base directory of the project, from where the Modello models are loaded.
      */
-    @Parameter( defaultValue = "${basedir}", readonly = true, required = true )
+    @Parameter( defaultValue = "${basedir}", required = true )
     private String basedir;
 
     /**


### PR DESCRIPTION
used in https://github.com/apache/maven/commit/74548dde8e399cb5b859f15ac9e46376b67bcb23#diff-91081af7c7d8c77b1b3cff89dd3b257e2967696c2f6d48aa65e827e1e2915a7aR53 for https://issues.apache.org/jira/browse/MNG-7664
it works because Maven does not really block such readonly parameters, but it currently prints a warning, and we hope that in the future such a case will fail