### PR TITLE
Improve discovering javaSource based on maven.compiler properties, default as 8

### DIFF
--- a/modello-core/src/main/java/org/codehaus/modello/ModelloParameterConstants.java
+++ b/modello-core/src/main/java/org/codehaus/modello/ModelloParameterConstants.java
@@ -51,6 +51,8 @@ public class ModelloParameterConstants {
      */
     public static final String OUTPUT_JAVA_SOURCE = "modello.output.java.source";
 
+    public static final String OUTPUT_JAVA_SOURCE_DEFAULT = "8";
+
     public static final String OUTPUT_XDOC_FILE_NAME = "modello.output.xdoc.file";
 
     public static final String OUTPUT_XSD_FILE_NAME = "modello.output.xsd.file";

--- a/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojoTest.java
+++ b/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojoTest.java
@@ -1,0 +1,78 @@
+package org.codehaus.modello.maven;
+
+import java.util.Properties;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.modello.ModelloParameterConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractModelloSourceGeneratorMojoTest {
+
+    private class ModelloSourceGeneratorMojoTest extends AbstractModelloSourceGeneratorMojo {
+
+        private final Properties projectProperties;
+
+        ModelloSourceGeneratorMojoTest(Properties projectProperties) {
+            this.projectProperties = projectProperties;
+        }
+
+        @Override
+        protected String getGeneratorType() {
+            return null;
+        }
+
+        @Override
+        public MavenProject getProject() {
+            Model model = new Model();
+            model.setProperties(projectProperties);
+            MavenProject project = new MavenProject();
+            project.setModel(model);
+            return project;
+        }
+    }
+
+    private void executeJavaSourceTest(Properties projectProperties, String expexted) {
+        ModelloSourceGeneratorMojoTest modelloSourceGeneratorMojoTest =
+                new ModelloSourceGeneratorMojoTest(projectProperties);
+        Properties properties = new Properties();
+
+        modelloSourceGeneratorMojoTest.customizeParameters(properties);
+
+        assertEquals(properties.getProperty(ModelloParameterConstants.OUTPUT_JAVA_SOURCE), expexted);
+    }
+
+    @Test
+    public void testJavaSourceDefault() {
+        executeJavaSourceTest(new Properties(), ModelloParameterConstants.OUTPUT_JAVA_SOURCE_DEFAULT);
+    }
+
+    @Test
+    public void testJavaSourceFromRelease() {
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.release", "11");
+        projectProperties.setProperty("maven.compiler.source", "xxx");
+        projectProperties.setProperty("maven.compiler.target", "xxx");
+
+        executeJavaSourceTest(projectProperties, "11");
+    }
+
+    @Test
+    public void testJavaSourceFromSource() {
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.source", "11");
+        projectProperties.setProperty("maven.compiler.target", "xxx");
+
+        executeJavaSourceTest(projectProperties, "11");
+    }
+
+    @Test
+    public void testJavaSourceFromTarget() {
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.target", "11");
+
+        executeJavaSourceTest(projectProperties, "11");
+    }
+}

--- a/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/ModelloConvertersMojoTest.java
+++ b/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/ModelloConvertersMojoTest.java
@@ -25,6 +25,7 @@ package org.codehaus.modello.maven;
 import java.io.File;
 import java.util.Arrays;
 
+import org.apache.maven.project.MavenProject;
 import org.codehaus.modello.core.ModelloCore;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusTestCase;
@@ -65,6 +66,8 @@ public class ModelloConvertersMojoTest extends PlexusTestCase {
         mojo.setModelloCore(modelloCore);
 
         mojo.setBuildContext(buildContext);
+
+        mojo.setProject(new MavenProject());
 
         mojo.execute();
 

--- a/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/ModelloJavaMojoTest.java
+++ b/modello-maven-plugin/src/test/java/org/codehaus/modello/maven/ModelloJavaMojoTest.java
@@ -25,6 +25,7 @@ package org.codehaus.modello.maven;
 import java.io.File;
 import java.util.Arrays;
 
+import org.apache.maven.project.MavenProject;
 import org.codehaus.modello.core.ModelloCore;
 import org.codehaus.plexus.ContainerConfiguration;
 import org.codehaus.plexus.PlexusTestCase;
@@ -65,6 +66,7 @@ public class ModelloJavaMojoTest extends PlexusTestCase {
         mojo.setModelloCore(modelloCore);
 
         mojo.setBuildContext(buildContext);
+        mojo.setProject(new MavenProject());
 
         mojo.execute();
 


### PR DESCRIPTION
We can recognize based on properties:
- maven.compiler.release
- maven.compiler.source
- maven.compiler.target

fix #194