### PR TITLE
Parse javadoc tags in xdoc generator (only @since is supported atm)

### DIFF
--- a/modello-plugins/modello-plugin-xdoc/pom.xml
+++ b/modello-plugins/modello-plugin-xdoc/pom.xml
@@ -31,6 +31,11 @@
       <version>1.17.2</version>
     </dependency>
     <dependency>
+      <groupId>com.github.chhorz</groupId>
+      <artifactId>javadoc-parser</artifactId>
+      <version>0.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
       <version>2.9.1</version>

--- a/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
@@ -23,6 +23,7 @@ package org.codehaus.modello.plugin.xdoc;
  */
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -77,7 +78,10 @@ public class XdocGeneratorTest extends AbstractModelloGeneratorTest {
                 .withTest(Input.fromFile(new File(getOutputDirectory(), "html4.xml")))
                 .build();
 
-        assertFalse(diff.toString(), diff.hasDifferences());
+        assertFalse(
+                diff.toString() + "\nGenerated output:\n"
+                        + new String(Files.readAllBytes(new File(getOutputDirectory(), "html4.xml").toPath())),
+                diff.hasDifferences());
     }
 
     private void checkMavenXdocGenerator() throws Exception {

--- a/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.expected.xml
+++ b/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.expected.xml
@@ -17,8 +17,11 @@
 </source>
       <a name="class_model"/>
       <subsection name="model">
-        <p>This is a description in HTML4
-<br /><strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag</p>
+        <p>Whether this proxy configuration is the active one. Note: While the type of this field is <code>String</code> for technical reasons, the semantic type is actually <code>boolean</code>.
+<br />
+ This is a description in HTML4
+<br /><strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag
+<p><b>Since</b>: Maven 3</p></p>
         <table>
           <tr>
             <th>Element</th>

--- a/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.expected.xml
+++ b/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.expected.xml
@@ -21,6 +21,7 @@
 <br />
  This is a description in HTML4
 <br /><strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag
+<br />
 <p><b>Since</b>: Maven 3</p></p>
         <table>
           <tr>

--- a/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.mdo
+++ b/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.mdo
@@ -19,7 +19,7 @@
             Whether this proxy configuration is the active one. Note: While the type of this field
             is {@code String} for technical reasons, the semantic type is actually {@code boolean}.<br>
             This is a description in HTML4<br>
-            <strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag
+            <strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag<br>
             @since Maven 3
           ]]>
       </description>

--- a/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.mdo
+++ b/modello-plugins/modello-plugin-xdoc/src/test/resources/html4.mdo
@@ -16,8 +16,11 @@
       <comment>This is a comment</comment>
       <description>
         <![CDATA[
+            Whether this proxy configuration is the active one. Note: While the type of this field
+            is {@code String} for technical reasons, the semantic type is actually {@code boolean}.<br>
             This is a description in HTML4<br>
             <strong>NOTE: </strong> HTML linebreak should be converted to selfclosing XML-tag
+            @since Maven 3
           ]]>
       </description>
       <name>Model</name>


### PR DESCRIPTION
This fixes new javadoc syntax:
<img width="725" alt="image" src="https://github.com/codehaus-plexus/modello/assets/84022/c70b3c3b-7aa1-444f-9dd4-ea5e63a0785f">
instead of 
<img width="737" alt="image" src="https://github.com/codehaus-plexus/modello/assets/84022/e96f6633-8419-4692-9c84-556050d5c5ab">

and adds support for `@since` tag:
<img width="471" alt="image" src="https://github.com/codehaus-plexus/modello/assets/84022/8ba9392e-3ff8-4da0-9f46-b9f358fbbed7">
instead of 
<img width="555" alt="image" src="https://github.com/codehaus-plexus/modello/assets/84022/adfb16e8-9104-4c9c-bad6-beec0f04ace3">

We may want to add support for more javadoc tags, but not sure which ones are used.  For example the `@see` tag may be used, but we don't have any way to point to the actual target.  All other tags (other than `@since`) are currently discarded.