### PR TITLE
Support java source property being discovered as 1.x

### DIFF
--- a/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojo.java
+++ b/modello-maven-plugin/src/main/java/org/codehaus/modello/maven/AbstractModelloSourceGeneratorMojo.java
@@ -94,12 +94,11 @@ public abstract class AbstractModelloSourceGeneratorMojo extends AbstractModello
             parameters.setProperty(ModelloParameterConstants.ENCODING, encoding);
         }
 
-        if (javaSource != null) {
-            if (javaSource.startsWith("1.")) {
-                javaSource = javaSource.substring("1.".length());
-            }
-        } else {
+        if (javaSource == null) {
             javaSource = discoverJavaSource();
+        }
+        if (javaSource.startsWith("1.")) {
+            javaSource = javaSource.substring("1.".length());
         }
         getLog().debug("javaSource=" + javaSource);
         parameters.setProperty(ModelloParameterConstants.OUTPUT_JAVA_SOURCE, javaSource);


### PR DESCRIPTION
The current code break maven with an error :
```
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] --------------------------------------------------------------------------------------------------------------------------
[INFO] Total time:  4.690 s
[INFO] Finished at: 2024-02-17T05:00:58+01:00
[INFO] --------------------------------------------------------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.modello:modello-maven-plugin:2.1.3-SNAPSHOT:java (modello) on project maven-compat: Error generating: For input string: "1.8" -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.modello:modello-maven-plugin:2.1.3-SNAPSHOT:java (modello) on project maven-compat: Error generating: For input string: "1.8"
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:331)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.MultiThreadedBuilder.lambda$build$10(MultiThreadedBuilder.java:263)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Caused by: org.apache.maven.plugin.MojoExecutionException: Error generating: For input string: "1.8"
    at org.codehaus.modello.maven.AbstractModelloGeneratorMojo.doExecute(AbstractModelloGeneratorMojo.java:277)
    at org.codehaus.modello.maven.AbstractModelloGeneratorMojo.execute(AbstractModelloGeneratorMojo.java:177)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.MultiThreadedBuilder.lambda$build$10(MultiThreadedBuilder.java:263)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NumberFormatException: For input string: "1.8"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
    at java.lang.Integer.parseInt(Integer.java:662)
    at java.lang.Integer.valueOf(Integer.java:989)
    at java.util.Optional.map(Optional.java:260)
    at org.codehaus.modello.plugin.java.AbstractJavaModelloGenerator.initialize(AbstractJavaModelloGenerator.java:74)
    at org.codehaus.modello.plugin.java.JavaModelloGenerator.generate(JavaModelloGenerator.java:96)
    at org.codehaus.modello.core.DefaultModelloCore.generate(DefaultModelloCore.java:275)
    at org.codehaus.modello.maven.AbstractModelloGeneratorMojo.doExecute(AbstractModelloGeneratorMojo.java:210)
    at org.codehaus.modello.maven.AbstractModelloGeneratorMojo.execute(AbstractModelloGeneratorMojo.java:177)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.MultiThreadedBuilder.lambda$build$10(MultiThreadedBuilder.java:263)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
[ERROR] 
[ERROR] Re-run Maven using the '-X' switch to enable verbose output
```