### PR TITLE
threadsafety

### DIFF
--- a/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
+++ b/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
@@ -20,7 +20,6 @@ package org.codehaus.modello.plugin.velocity;
  */
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -43,7 +42,6 @@ import org.codehaus.modello.plugin.AbstractModelloGenerator;
 import org.codehaus.plexus.util.io.CachingWriter;
 
 @Named("velocity")
-@Singleton
 public class VelocityGenerator extends AbstractModelloGenerator {
     public static final String VELOCITY_BASEDIR = "modello.velocity.basedir";
 

--- a/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
+++ b/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
@@ -23,7 +23,6 @@ package org.codehaus.modello.plugin.xdoc;
  */
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,7 +67,6 @@ import org.jsoup.nodes.Document;
  * @author <a href="mailto:emmanuel@venisse.net">Emmanuel Venisse</a>
  */
 @Named("xdoc")
-@Singleton
 public class XdocGenerator extends AbstractXmlGenerator {
     private static final VersionRange DEFAULT_VERSION_RANGE = new VersionRange("0.0.0+");
 

--- a/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
+++ b/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
@@ -28,6 +28,7 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -56,9 +57,9 @@ import org.codehaus.modello.plugins.xml.metadata.XmlClassMetadata;
 import org.codehaus.modello.plugins.xml.metadata.XmlFieldMetadata;
 import org.codehaus.modello.plugins.xml.metadata.XmlModelMetadata;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.io.CachingWriter;
 import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
 import org.codehaus.plexus.util.xml.XMLWriter;
-import org.codehaus.plexus.util.xml.XmlStreamWriter;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
@@ -115,7 +116,7 @@ public class XdocGenerator extends AbstractXmlGenerator {
             f = new File(directory, xdocFileName);
         }
 
-        Writer writer = new XmlStreamWriter(f);
+        Writer writer = new CachingWriter(f, StandardCharsets.UTF_8);
 
         XMLWriter w = new PrettyPrintXMLWriter(writer);
 

--- a/modello-plugins/modello-plugin-xsd/src/main/java/org/codehaus/modello/plugin/xsd/XsdGenerator.java
+++ b/modello-plugins/modello-plugin-xsd/src/main/java/org/codehaus/modello/plugin/xsd/XsdGenerator.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -43,9 +44,9 @@ import org.codehaus.modello.plugins.xml.AbstractXmlGenerator;
 import org.codehaus.modello.plugins.xml.metadata.XmlAssociationMetadata;
 import org.codehaus.modello.plugins.xml.metadata.XmlFieldMetadata;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.io.CachingWriter;
 import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
 import org.codehaus.plexus.util.xml.XMLWriter;
-import org.codehaus.plexus.util.xml.XmlStreamWriter;
 
 /**
  * @author <a href="mailto:brett@codehaus.org">Brett Porter</a>
@@ -93,7 +94,7 @@ public class XsdGenerator extends AbstractXmlGenerator {
             f = new File(directory, xsdFileName);
         }
 
-        Writer writer = new XmlStreamWriter(f);
+        Writer writer = new CachingWriter(f, StandardCharsets.UTF_8);
 
         try {
             XMLWriter w = new PrettyPrintXMLWriter(writer);


### PR DESCRIPTION
- Use caching writers when writing xsd / xdoc
- Do not use singletons for generators
