### PR TITLE
XDOC: document required fields in generated model docs

### DIFF
--- a/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
+++ b/modello-plugins/modello-plugin-xdoc/src/main/java/org/codehaus/modello/plugin/xdoc/XdocGenerator.java
@@ -417,6 +417,10 @@ public class XdocGenerator extends AbstractXmlGenerator {
 
             w.writeMarkup(getDescription(f));
 
+            if (f.isRequired()) {
+                w.writeMarkup("<p><strong>Required</strong>: Yes.</p>");
+            }
+
             // Write the default value, if it exists.
             // But only for fields that are not a ModelAssociation
             if (f.getDefaultValue() != null && !(f instanceof ModelAssociation)) {

--- a/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
@@ -135,6 +135,16 @@ public class XdocGeneratorTest extends AbstractModelloGeneratorTest {
 
         // verify( "org.codehaus.modello.generator.xml.cdoc.XdocVerifier", "xdoc" );
         checkInternalLinks("maven.xml");
+
+        String content = FileUtils.fileRead(new File(getOutputDirectory(), "maven.xml"), "UTF-8");
+
+        Pattern requiredModelVersion =
+                Pattern.compile("<code>modelVersion</code>.*?<strong>Required</strong>: Yes\\.", Pattern.DOTALL);
+        assertTrue(requiredModelVersion.matcher(content).find(), "Required modelVersion field should be documented");
+
+        Pattern requiredGroupId =
+                Pattern.compile("<code>groupId</code>.*?<strong>Required</strong>: Yes\\.", Pattern.DOTALL);
+        assertTrue(requiredGroupId.matcher(content).find(), "Required groupId field should be documented");
     }
 
     public void checkFeaturesXdocGenerator() throws Exception {


### PR DESCRIPTION
## Summary
This PR fixes #549 by exposing whether a field is required in generated xdoc documentation.

## Changes
- render `Required: Yes.` in generated xdoc for fields with `required=true`
- add regression test assertions for `modelVersion` and `groupId` in generated `maven.xml`

## Verification
- mvn -pl modello-plugins/modello-plugin-xdoc -Dtest=XdocGeneratorTest test

Closes #549