### PR TITLE
Initialize model parameters in VelocityGenerator

### DIFF
--- a/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
+++ b/modello-plugins/modello-plugin-velocity/src/main/java/org/codehaus/modello/plugin/velocity/VelocityGenerator.java
@@ -54,6 +54,7 @@ public class VelocityGenerator extends AbstractModelloGenerator {
     @Override
     @SuppressWarnings("unchecked")
     public void generate(Model model, Map<String, Object> parameters) throws ModelloException {
+        initialize(model, parameters);
         try {
             Map<String, String> params =
                     (Map<String, String>) Objects.requireNonNull(parameters.get(VELOCITY_PARAMETERS));


### PR DESCRIPTION
What changed:
- Added call to `initialize(model, parameters)` in the `generate` method.

Why:
- To ensure that the model is properly initialized with the provided parameters.