### PR TITLE
Allow arbitrary attributes on DOM elements in generated XSD

### DIFF
--- a/modello-plugins/modello-plugin-xsd/src/main/java/org/codehaus/modello/plugin/xsd/XsdGenerator.java
+++ b/modello-plugins/modello-plugin-xsd/src/main/java/org/codehaus/modello/plugin/xsd/XsdGenerator.java
@@ -324,7 +324,7 @@ public class XsdGenerator extends AbstractXmlGenerator {
                             writeListElement(w, xmlFieldMetadata, xmlAssociationMetadata, field, getXsdType("String"));
                         } else if (Properties.class.getName().equals(field.getType())
                                 || "DOM".equals(field.getType())) {
-                            writePropertiesElement(w);
+                            writePropertiesElement(w, "DOM".equals(field.getType()));
                         } else {
                             throw new IllegalStateException("Non-association field of a non-primitive type '"
                                     + field.getType() + "' for '" + field.getName() + "' in '"
@@ -408,7 +408,16 @@ public class XsdGenerator extends AbstractXmlGenerator {
         w.endElement();
     }
 
-    private static void writePropertiesElement(XMLWriter w) {
+    /**
+     * Writes the complexType of a field holding free-form XML content: either a {@code java.util.Properties} or
+     * a {@code DOM} field.
+     *
+     * @param w the writer
+     * @param dom whether the field is a {@code DOM} field, in which case arbitrary attributes are allowed on the
+     *            element itself, so that DOM merge hints such as {@code combine.self} or {@code combine.children}
+     *            validate. A {@code Properties} element carries no attributes, so none are allowed there.
+     */
+    private static void writePropertiesElement(XMLWriter w, boolean dom) {
         w.startElement("xs:complexType");
 
         w.startElement("xs:sequence");
@@ -421,6 +430,13 @@ public class XsdGenerator extends AbstractXmlGenerator {
         w.endElement();
 
         w.endElement();
+
+        if (dom) {
+            w.startElement("xs:anyAttribute");
+            w.addAttribute("processContents", "skip");
+
+            w.endElement();
+        }
 
         w.endElement();
     }

--- a/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/DomXsdGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/DomXsdGeneratorTest.java
@@ -1,0 +1,88 @@
+package org.codehaus.modello.plugin.xsd;
+
+/*
+ * Copyright (c) 2005, Codehaus.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import javax.inject.Inject;
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import java.io.File;
+import java.util.Map;
+
+import org.codehaus.modello.AbstractModelloGeneratorTest;
+import org.codehaus.modello.ModelloException;
+import org.codehaus.modello.core.ModelloCore;
+import org.codehaus.modello.model.Model;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXParseException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Checks that a DOM field accepts arbitrary attributes on its element, so that DOM merge hints such as
+ * {@code combine.self} validate, while a Properties field does not.
+ *
+ * @see <a href="https://github.com/codehaus-plexus/modello/issues/482">issue 482</a>
+ */
+@PlexusTest
+public class DomXsdGeneratorTest extends AbstractModelloGeneratorTest {
+    @Inject
+    private ModelloCore modello;
+
+    public DomXsdGeneratorTest() {
+        super("xsd-dom");
+    }
+
+    @Test
+    public void testDomAttributesAreAllowed() throws Throwable {
+        Model model = modello.loadModel(getXmlResourceReader("/dom.mdo"));
+
+        Map<String, Object> parameters = getModelloParameters("1.0.0");
+
+        modello.generate(model, "xsd", parameters);
+
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = sf.newSchema(new StreamSource(new File(getOutputDirectory(), "dom-1.0.0.xsd")));
+        Validator validator = schema.newValidator();
+
+        try {
+            validator.validate(new StreamSource(getClass().getResourceAsStream("/dom.xml")));
+        } catch (SAXParseException e) {
+            throw new ModelloException("line " + e.getLineNumber() + " column " + e.getColumnNumber(), e);
+        }
+
+        try {
+            validator.validate(
+                    new StreamSource(getClass().getResourceAsStream("/dom-invalid-properties-attribute.xml")));
+            fail("attributes should not be allowed on a Properties element");
+        } catch (SAXParseException e) {
+            // ok, expected exception
+            assertTrue(e.getMessage().contains("combine.self"));
+        }
+    }
+}

--- a/modello-plugins/modello-plugin-xsd/src/test/resources/dom-invalid-properties-attribute.xml
+++ b/modello-plugins/modello-plugin-xsd/src/test/resources/dom-invalid-properties-attribute.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<domDemo xmlns="http://codehaus-plexus.github.io/DOM/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://codehaus-plexus.github.io/DOM/1.0.0 http://codehaus-plexus.github.io/dom-1.0.0.xsd">
+  <properties combine.self="override">
+    <someKey>someValue</someKey>
+  </properties>
+</domDemo>

--- a/modello-plugins/modello-plugin-xsd/src/test/resources/dom.mdo
+++ b/modello-plugins/modello-plugin-xsd/src/test/resources/dom.mdo
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/2.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/2.0.0 https://codehaus-plexus.github.io/modello/xsd/modello-2.0.0.xsd"
+       xml.namespace="http://codehaus-plexus.github.io/DOM/${version}"
+       xml.schemaLocation="http://codehaus-plexus.github.io/DOM/${version} http://codehaus-plexus.github.io/dom-${version}.xsd">
+  <id>dom</id>
+  <name>Dom</name>
+  <description>
+    Model exercising the XSD generated for DOM and Properties fields.
+  </description>
+  <defaults>
+    <default>
+      <key>package</key>
+      <value>org.codehaus.modello.test.dom</value>
+    </default>
+  </defaults>
+  <classes>
+    <class rootElement="true">
+      <name>DomDemo</name>
+      <version>1.0.0+</version>
+      <fields>
+        <field>
+          <name>configuration</name>
+          <version>1.0.0+</version>
+          <type>DOM</type>
+          <description>Free-form XML, carrying arbitrary attributes such as combine.self.</description>
+        </field>
+        <field>
+          <name>properties</name>
+          <version>1.0.0+</version>
+          <type>Properties</type>
+          <association xml.mapStyle="inline">
+            <type>String</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description>Free-form XML elements, but no attributes on the container.</description>
+        </field>
+      </fields>
+    </class>
+  </classes>
+</model>

--- a/modello-plugins/modello-plugin-xsd/src/test/resources/dom.xml
+++ b/modello-plugins/modello-plugin-xsd/src/test/resources/dom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<domDemo xmlns="http://codehaus-plexus.github.io/DOM/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://codehaus-plexus.github.io/DOM/1.0.0 http://codehaus-plexus.github.io/dom-1.0.0.xsd">
+  <configuration combine.self="override">
+    <goalPrefix combine.self="override"/>
+  </configuration>
+  <properties>
+    <someKey>someValue</someKey>
+  </properties>
+</domDemo>


### PR DESCRIPTION
Reworked version of #483, which fixes #482.

A `DOM` field maps to an element carrying free-form XML, so DOM merge hints may appear on it:

```xml
<configuration combine.self="override">
  <goalPrefix combine.self="override"/>
</configuration>
```

The generated `xs:complexType` declared no attributes, so this failed schema validation even though Maven accepts it. Nested elements were already covered by the existing `xs:any processContents="skip"`; only the element itself was missing an attribute wildcard.

### Changes

- `XsdGenerator` emits `<xs:anyAttribute processContents="skip"/>` for `DOM` fields.
- `writePropertiesElement` is shared by `DOM` and `java.util.Properties` fields, so it now takes a flag. A `Properties` container element never carries attributes, so it keeps the stricter schema and typos there are still reported.
- New `DomXsdGeneratorTest`, following `FeaturesXsdGeneratorTest`: it generates the schema, validates a document using `combine.self` on the DOM element, and asserts that the same attribute on a `Properties` element is still rejected. The test fails without the generator change.

### Differences from #483

- Rebased onto current `master` — that PR predates the test migration in #523 and no longer compiles (`lookup(ModelloCore.ROLE)`, no `@Test`/`@PlexusTest`).
- The wildcard is restricted to `DOM`; #483 also loosened `Properties`.
- Assertions added; #483 only checked that generation did not throw.
- The 3328-line copy of Apache Maven's `maven.mdo` is replaced by a 42-line `dom.mdo`, and the test gets its own output directory instead of sharing `target/generator-results/xsd` with `XsdGeneratorTest`.

Credit to @XenoAmess for the diagnosis and the original patch.
