### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/modello-maven-plugin/src/site/markdown/examples/multi-model.md.vm
+++ b/modello-maven-plugin/src/site/markdown/examples/multi-model.md.vm
@@ -1,3 +1,10 @@
+---
+title: Example of multi-model configuration
+author: 
+  - Denis Cabasson
+date: 10 August 2006
+---
+
 # Processing Multiple Modello Models
 
 Configuring your pom.xml

--- a/modello-maven-plugin/src/site/markdown/index.md
+++ b/modello-maven-plugin/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Introduction
+author: 
+  - Denis Cabasson
+  - Hervé Boutemy
+date: 1 January 2009
+---
+
 # Modello Maven Plugin
 
 This plugin makes use of the [Modello](https://codehaus-plexus.github.io/modello/) project.

--- a/modello-maven-plugin/src/site/markdown/usage.md.vm
+++ b/modello-maven-plugin/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Denis Cabasson
+date: 10 August 2006
+---
+
 # Usage
 
 This document is intended to provide instructions for using the modello-maven-plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>25</version>
+    <version>26</version>
   </parent>
 
   <groupId>org.codehaus.modello</groupId>

--- a/src/site/markdown/location-tracking.md
+++ b/src/site/markdown/location-tracking.md
@@ -1,3 +1,10 @@
+---
+title: Location Tracking
+author: 
+  - Benjamin Bentmann
+date: 2010-04-18
+---
+
 # Location Tracking
 
 Starting with Modello 1.4, some parsers (only [XPP3](./modello-plugins/modello-plugin-xpp3/index.html) in 1.4, [Snake Yaml](./modello-plugins/modello-plugin-snakeyaml/) and [Jackson](./modello-plugins/modello-plugin-jackson/) in addition in 1.8) support the tracking of line/column information for the input data. This means that additional metadata is stored in the model that can be used to query the location of some model element in the input source, e.g. for means of better error reporting to the user.

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -1,3 +1,10 @@
+---
+title: Release Notes
+author: 
+  - Hervé Boutemy
+date: 2012-11-18
+---
+
 # Modello
 
 ## 1.8.2


### PR DESCRIPTION
Unblocked by the release of plexus parent 26.

The APT sources carried a title, an author and a date. Converting the pages to Markdown
dropped them, so every generated page lost its `<title>` and its author meta. This puts
them back as YAML front matter.

It could not be done before now. Parent 25 runs Spotless over `**/*.md`, and flexmark
rewrites the fence that closes a front matter block into a setext underline, which costs
the page exactly the metadata being restored — silently, with a green build. Parent 26
excludes `**/src/site/markdown/**`, so the first commit here is the parent upgrade.

Verified after the bump: the front matter survives the build and the generated pages carry
both title and author.

```
<title>Location Tracking – Modello</title>
<meta name="author" content="Benjamin Bentmann" />
```

`migration-guide.md` is deliberately untouched — it was authored as Markdown and never had
metadata to restore; only `location-tracking.apt` and `release-notes.apt` existed as APT.