### PR TITLE
Add the Publish Site workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Publish Site
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Build the site and check out gh-pages without committing'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  site:
+    uses: codehaus-plexus/.github/.github/workflows/site.yml@master
+    with:
+      multi-module: true
+      dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
Part of codehaus-plexus/.github#58. Second caller for the shared workflow (codehaus-plexus/.github#62), and the **multi-module** form — the companion to codehaus-plexus/plexus-utils#334, which is the single-module one.

The only difference between the two is one line:

```yaml
    with:
      multi-module: true
```

That switches the shared workflow from `site-deploy` to `site site:stage scm-publish:publish-scm`. Required here because the site has to be assembled across the four modules before it is pushed, and `site-deploy` alone would publish only the aggregator.

Nothing else needs configuring: `maven-scm-publish-plugin` defaults `content` to `${project.build.directory}/staging`, which is exactly what `site:stage` produces. I checked that in the plugin descriptor rather than assuming it.

The other multi-module repos are `plexus-compiler`, `plexus-languages` and `plexus-interactivity`; they will get the identical file.

**Please run it with `dry-run` ticked first** — it builds the site and checks out `gh-pages` without committing, which is the safe way to confirm the token permission and the `pubScmUrl` rewrite work. I have not run it; the first real publish should be a maintainer’s call.