### PR TITLE
Compile the verifiers with the JDK compiler and the test classpath

### DIFF
--- a/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
+++ b/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
@@ -54,9 +54,6 @@ public class ConverterGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         generateConverterClasses(getXmlResourceReader("/features.mdo"), "1.0.0", "1.1.0");
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("ConvertersVerifier");

--- a/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
@@ -93,8 +93,6 @@ public class Dom4jGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "dom4j-writer", parameters);
         modello.generate(model, "dom4j-reader", parameters);
 
-        addDependency("dom4j", "dom4j");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.dom4j.Dom4jVerifier");

--- a/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/FeaturesDom4jGeneratorTest.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/FeaturesDom4jGeneratorTest.java
@@ -54,8 +54,6 @@ public class FeaturesDom4jGeneratorTest extends AbstractModelloJavaGeneratorTest
         modello.generate(model, "dom4j-writer", parameters);
         modello.generate(model, "dom4j-reader", parameters);
 
-        addDependency("dom4j", "dom4j");
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.dom4j.Dom4jFeaturesVerifier");

--- a/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
@@ -65,10 +65,6 @@ public class JacksonGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "jackson-writer", parameters);
         modello.generate(model, "jackson-reader", parameters);
 
-        addDependency("com.fasterxml.jackson.core", "jackson-core");
-        addDependency("com.fasterxml.jackson.core", "jackson-databind");
-        // looks like jackson-databind requires jackson-annotations to run...
-        addDependency("com.fasterxml.jackson.core", "jackson-annotations");
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
@@ -52,8 +52,6 @@ public class AnnotationsJavaGeneratorTest extends AbstractModelloJavaGeneratorTe
 
         modello.generate(model, "java", parameters);
 
-        addDependency("javax.xml.bind", "jaxb-api");
-        addDependency("javax.persistence", "persistence-api");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("AnnotationsVerifier");

--- a/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/FeaturesJDOMGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/FeaturesJDOMGeneratorTest.java
@@ -54,8 +54,6 @@ public class FeaturesJDOMGeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "stax-reader", parameters);
         modello.generate(model, "jdom-writer", parameters);
 
-        addDependency("org.jdom", "jdom");
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.jdom.JDOMFeaturesVerifier");

--- a/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/RootClassnameJDOMGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/RootClassnameJDOMGeneratorTest.java
@@ -55,7 +55,6 @@ public class RootClassnameJDOMGeneratorTest extends AbstractModelloJavaGenerator
         modello.generate(model, "java", parameters);
         modello.generate(model, "jdom-writer", parameters);
 
-        addDependency("org.jdom", "jdom");
         compileGeneratedSources();
 
         // If the code compiles successfully, the test passes

--- a/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
@@ -92,7 +92,6 @@ public class SaxGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "java", parameters);
         modello.generate(model, "sax-writer", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources();
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-snakeyaml/src/test/java/org/codehaus/modello/plugin/snakeyaml/SnakeYamlGeneratorTest.java
+++ b/modello-plugins/modello-plugin-snakeyaml/src/test/java/org/codehaus/modello/plugin/snakeyaml/SnakeYamlGeneratorTest.java
@@ -52,7 +52,6 @@ public class SnakeYamlGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "snakeyaml-writer", parameters);
         modello.generate(model, "snakeyaml-reader", parameters);
 
-        addDependency("org.yaml", "snakeyaml");
         compileGeneratedSources();
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
@@ -73,9 +73,6 @@ public abstract class AbstractStaxGeneratorTestCase extends AbstractModelloJavaG
             }
         }
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources(className);

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
@@ -55,10 +55,6 @@ public class FeaturesStaxDomGeneratorTest extends AbstractModelloJavaGeneratorTe
         modello.generate(model, "stax-writer", parameters);
         modello.generate(model, "stax-reader", parameters);
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-        addDependency("org.xmlunit", "xmlunit-core");
-
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
@@ -54,10 +54,6 @@ public class FeaturesStaxGeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "stax-writer", parameters);
         modello.generate(model, "stax-reader", parameters);
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-        addDependency("org.xmlunit", "xmlunit-core");
-
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
@@ -56,7 +56,6 @@ public class FeaturesXpp3DomGeneratorTest extends AbstractModelloJavaGeneratorTe
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesVerifier");

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3GeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3GeneratorTest.java
@@ -54,7 +54,6 @@ public class FeaturesXpp3GeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesVerifier");

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
@@ -95,7 +95,6 @@ public class Xpp3GeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/pom.xml
+++ b/modello-plugins/pom.xml
@@ -61,28 +61,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-test-libs</id>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-              <phase>process-test-resources</phase>
-              <configuration>
-                <outputDirectory>${project.build.directory}/test-libs</outputDirectory>
-                <excludeTransitive>false</excludeTransitive>
-                <stripVersion>true</stripVersion>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/modello-test/pom.xml
+++ b/modello-test/pom.xml
@@ -12,9 +12,7 @@
   <description>Modello Test Package contains the basis to create Modello generator unit-tests, including sample models
     and xml files to test every feature for every plugin.</description>
 
-  <properties>
-    <plexus.compiler.version>2.16.2</plexus.compiler.version>
-  </properties>
+  <properties />
   <dependencies>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
@@ -27,16 +25,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexus.compiler.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-api</artifactId>
-      <version>${plexus.compiler.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
+++ b/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
@@ -22,32 +22,43 @@ package org.codehaus.modello;
  * SOFTWARE.
  */
 
-import javax.inject.Inject;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.codehaus.modello.verifier.VerifierException;
-import org.codehaus.plexus.compiler.Compiler;
-import org.codehaus.plexus.compiler.CompilerConfiguration;
-import org.codehaus.plexus.compiler.CompilerException;
-import org.codehaus.plexus.compiler.CompilerMessage;
-import org.codehaus.plexus.compiler.CompilerResult;
 import org.codehaus.plexus.util.FileUtils;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
 import static org.codehaus.plexus.testing.PlexusExtension.getTestPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,14 +71,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @see org.codehaus.modello.verifier.Verifier Verifier base class for verifiers
  */
 public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGeneratorTest {
-    private List<File> dependencies = new ArrayList<File>();
-
     private List<URL> urls = new ArrayList<URL>();
 
     private List<String> classPathElements = new ArrayList<String>();
-
-    @Inject
-    private Compiler compiler = null; // todo
 
     protected AbstractModelloJavaGeneratorTest(String name) {
         super(name);
@@ -87,29 +93,6 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         return new File(super.getOutputDirectory(), "classes");
     }
 
-    protected void addDependency(String groupId, String artifactId) {
-        File dependencyFile = getDependencyFile(groupId, artifactId);
-
-        dependencies.add(dependencyFile);
-
-        addClassPathFile(dependencyFile);
-    }
-
-    protected File getDependencyFile(String groupId, String artifactId) {
-        // NOTE: dependency version is managed by project POM and not selectable by test
-
-        String libsDir = System.getProperty("tests.lib.dir", "target/test-libs");
-        File dependencyFile = new File(libsDir, artifactId + ".jar");
-
-        assertTrue(dependencyFile.isFile(), "Can't find dependency: " + dependencyFile.getAbsolutePath());
-
-        return dependencyFile;
-    }
-
-    public List<File> getClasspath() {
-        return dependencies;
-    }
-
     protected String getModelloVersion() throws IOException {
         Properties properties = new Properties(System.getProperties());
 
@@ -125,15 +108,15 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         return properties.getProperty("version");
     }
 
-    protected void compileGeneratedSources() throws IOException, CompilerException {
+    protected void compileGeneratedSources() throws IOException {
         compileGeneratedSources(getName(), 8);
     }
 
-    protected void compileGeneratedSources(int minJavaSource) throws IOException, CompilerException {
+    protected void compileGeneratedSources(int minJavaSource) throws IOException {
         compileGeneratedSources(getName(), minJavaSource);
     }
 
-    protected void compileGeneratedSources(String verifierId, int minJavaSource) throws IOException, CompilerException {
+    protected void compileGeneratedSources(String verifierId, int minJavaSource) throws IOException {
         String runtimeVersion = System.getProperty("java.specification.version");
         if (runtimeVersion.startsWith("1.")) {
             runtimeVersion = runtimeVersion.substring(2);
@@ -151,54 +134,122 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         compileGeneratedSources(verifierId, javaSource);
     }
 
-    private void compileGeneratedSources(String verifierId, String javaSource) throws IOException, CompilerException {
+    private void compileGeneratedSources(String verifierId, String javaSource) throws IOException {
         File generatedSources = getOutputDirectory();
         File destinationDirectory = getOutputClasses();
 
-        addDependency("org.junit.jupiter", "junit-jupiter-api");
-        addDependency("org.opentest4j", "opentest4j");
-        addDependency("org.codehaus.plexus", "plexus-utils");
-        addDependency("org.codehaus.plexus", "plexus-xml");
-        // for plexus-xml 4
-        // addDependency("org.apache.maven", "maven-api-xml");
-        // addDependency("org.apache.maven", "maven-xml-impl");
-        addDependency("org.codehaus.modello", "modello-test");
+        List<String> classPath = new ArrayList<>();
+        classPath.add(getTestPath("target/classes"));
+        classPath.add(getTestPath("target/test-classes"));
+        classPath.addAll(resolveTestClasspath());
 
-        String[] classPathElements = new String[dependencies.size() + 2];
-        classPathElements[0] = getTestPath("target/classes");
-        classPathElements[1] = getTestPath("target/test-classes");
-
-        for (int i = 0; i < dependencies.size(); i++) {
-            classPathElements[i + 2] = ((File) dependencies.get(i)).getAbsolutePath();
-        }
-
+        List<File> sourceDirectories = new ArrayList<>();
         File verifierDirectory = getTestFile("src/test/verifiers/" + verifierId);
-        String[] sourceDirectories;
         if (verifierDirectory.canRead()) {
-            sourceDirectories = new String[] {verifierDirectory.getAbsolutePath(), generatedSources.getAbsolutePath()};
-        } else {
-            sourceDirectories = new String[] {generatedSources.getAbsolutePath()};
+            sourceDirectories.add(verifierDirectory);
+        }
+        sourceDirectories.add(generatedSources);
+
+        List<File> sourceFiles = new ArrayList<>();
+        for (File sourceDirectory : sourceDirectories) {
+            sourceFiles.addAll(findJavaSources(sourceDirectory));
         }
 
-        CompilerConfiguration configuration = new CompilerConfiguration();
-        configuration.setClasspathEntries(Arrays.asList(classPathElements));
-        configuration.setSourceLocations(Arrays.asList(sourceDirectories));
-        configuration.setOutputLocation(destinationDirectory.getAbsolutePath());
-        configuration.setDebug(true);
+        // javac up to Java 8 refuses a -d that does not already exist; later versions create it
+        Files.createDirectories(destinationDirectory.toPath());
 
-        configuration.setSourceVersion(javaSource);
-        configuration.setTargetVersion(javaSource);
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(javac, "No java compiler available - the tests need a JDK, not a JRE");
 
-        CompilerResult result = compiler.performCompile(configuration);
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = javac.getStandardFileManager(diagnostics, null, null)) {
+            List<String> options = Arrays.asList(
+                    "-g",
+                    "-classpath",
+                    String.join(File.pathSeparator, classPath),
+                    "-d",
+                    destinationDirectory.getAbsolutePath(),
+                    "-source",
+                    javaSource,
+                    "-target",
+                    javaSource);
 
-        List<CompilerMessage> errors = new ArrayList<CompilerMessage>(0);
-        for (CompilerMessage compilerMessage : result.getCompilerMessages()) {
-            if (compilerMessage.isError()) {
-                errors.add(compilerMessage);
-            }
+            javac.getTask(
+                            null,
+                            fileManager,
+                            diagnostics,
+                            options,
+                            null,
+                            fileManager.getJavaFileObjectsFromFiles(sourceFiles))
+                    .call();
         }
+
+        List<Diagnostic<? extends JavaFileObject>> errors = diagnostics.getDiagnostics().stream()
+                .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                .collect(Collectors.toList());
 
         assertEquals(0, errors.size(), "There was compilation errors: " + errors);
+    }
+
+    private static List<File> findJavaSources(File directory) throws IOException {
+        if (!directory.isDirectory()) {
+            return new ArrayList<>();
+        }
+        try (Stream<Path> paths = Files.walk(directory.toPath())) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Returns this module's test classpath, which is what the verifiers and the generated sources are compiled
+     * against.
+     * <p>
+     * Surefire normally hands the forked JVM a manifest-only "booter" jar rather than a real classpath, so
+     * {@code java.class.path} on its own is a single jar whose {@code Class-Path} manifest entry holds the actual
+     * entries. Expanding that keeps this in step with whatever the POM declares, with no build step to copy jars
+     * around and no second list to maintain here.
+     */
+    private static List<String> resolveTestClasspath() {
+        List<String> classPath = new ArrayList<>();
+        for (String entry : System.getProperty("java.class.path", "").split(File.pathSeparator)) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            classPath.add(entry);
+            // a jar may carry its own Class-Path, so keep both it and whatever it points at
+            classPath.addAll(expandManifestClassPath(new File(entry)));
+        }
+        return classPath;
+    }
+
+    private static List<String> expandManifestClassPath(File jar) {
+        if (!jar.isFile() || !jar.getName().endsWith(".jar")) {
+            return new ArrayList<>();
+        }
+        try (JarFile jarFile = new JarFile(jar)) {
+            Manifest manifest = jarFile.getManifest();
+            if (manifest == null) {
+                return new ArrayList<>();
+            }
+            String classPath = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
+            if (classPath == null || classPath.trim().isEmpty()) {
+                return new ArrayList<>();
+            }
+            List<String> entries = new ArrayList<>();
+            for (String entry : classPath.trim().split("\\s+")) {
+                try {
+                    entries.add(Paths.get(URI.create(entry)).toString());
+                } catch (IllegalArgumentException | java.nio.file.FileSystemNotFoundException e) {
+                    // a relative entry, resolved against the jar itself
+                    entries.add(new File(jar.getParentFile(), entry).getAbsolutePath());
+                }
+            }
+            return entries;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read the manifest of " + jar, e);
+        }
     }
 
     /**
@@ -212,6 +263,14 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         addClassPathFile(getTestFile("target/classes"));
 
         addClassPathFile(getTestFile("target/test-classes"));
+
+        // the verifier runs in a classloader with no parent, so it needs the test classpath spelled out
+        for (String entry : resolveTestClasspath()) {
+            File file = new File(entry);
+            if (file.exists()) {
+                addClassPathFile(file);
+            }
+        }
 
         ClassLoader oldCCL = Thread.currentThread().getContextClassLoader();
         URLClassLoader classLoader = URLClassLoader.newInstance(urls.toArray(new URL[urls.size()]), null);


### PR DESCRIPTION
Follow-up to #583.

The verifier compilation maintained its own idea of the classpath. Every jar it needed was copied into `target/test-libs` by a `copy-dependencies` execution with `stripVersion` on, then named again by hand:

```java
addDependency("org.junit.jupiter", "junit-jupiter-api");
addDependency("org.opentest4j", "opentest4j");
addDependency("org.codehaus.plexus", "plexus-utils");
...
```

plus 26 more `addDependency(...)` calls spread across the plugin tests. That is a second source of truth for something the POM already states, and it drifts — the harness was still adding `junit:junit` long after nothing needed it, which #583 removed. `stripVersion` also flattens two artifacts that share an artifactId into one file name, silently.

The compilation now runs on the module's own test classpath, taken from the running JVM: whatever the POM declares, nothing else, no jars copied and no list to maintain.

**Two details worth a look.** Surefire hands a forked JVM a manifest-only "booter" jar rather than a real classpath, so entries in a jar's `Class-Path` manifest attribute are expanded — and the jar itself is kept too, since an ordinary dependency may legitimately carry that attribute and dropping it would be wrong. Separately, `verifyCompiledGeneratedSources` builds a `URLClassLoader` with a **null parent**, so it needs the same list spelled out; that previously happened as a side effect of `addDependency`, and missing it produces `NoClassDefFoundError: org/codehaus/modello/verifier/Verifier`.

Compiling through `javax.tools` instead of plexus-compiler drops two more dependencies. Source and target levels are computed exactly as before.

Removed: the `copy-test-libs` execution, `plexus-compiler-api`, `plexus-compiler-javac`, `addDependency`, `getDependencyFile`, `getClasspath`, and the `tests.lib.dir` property. `modello-test` is published, so those last three are an API break for anyone extending the harness downstream — say the word and I will keep them as deprecated no-ops instead.

### Java 8

Unchanged, and checked rather than assumed. `javax.tools` has shipped since Java 6; `Files.walk`, `String.join`, `Stream`/`Collectors` and `UncheckedIOException` are all Java 8. The module builds under `maven.compiler.release=8` and `javap` reports major version 52 on the compiled class.

### Verification

Full reactor `mvn test`, before and after, is identical — same per-module totals, and the same 5 pre-existing `NullPointerException`s from `System.setProperty` (JDK 26, unrelated, present on `master` too).

A broken classpath here could easily have shown up as "everything still passes", so the verify path was checked negatively: corrupting one expected value in `JavaVerifier` produces

```
VerifierException: Error verifying modello tests: objectString ==> expected: <WRONG> but was: <default value>
```

so generate → compile-with-generated-sources → isolated classloader → reflective `verify()` all still genuinely runs.

`spotless:check` clean.

Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)
