### PR TITLE
Give every verifier a package and a unique class name

### DIFF
--- a/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
+++ b/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
@@ -54,9 +54,6 @@ public class ConverterGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         generateConverterClasses(getXmlResourceReader("/features.mdo"), "1.0.0", "1.1.0");
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("ConvertersVerifier");

--- a/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
+++ b/modello-plugins/modello-plugin-converters/src/test/java/org/codehaus/modello/plugin/converters/ConverterGeneratorTest.java
@@ -56,7 +56,7 @@ public class ConverterGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("ConvertersVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.converters.ConvertersVerifier");
     }
 
     private void generateConverterClasses(Reader modelReader, String fromVersion, String toVersion) throws Throwable {

--- a/modello-plugins/modello-plugin-converters/src/test/verifiers/converters/ConvertersVerifier.java
+++ b/modello-plugins/modello-plugin-converters/src/test/verifiers/converters/ConvertersVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.converters;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *

--- a/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
@@ -93,8 +93,6 @@ public class Dom4jGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "dom4j-writer", parameters);
         modello.generate(model, "dom4j-reader", parameters);
 
-        addDependency("dom4j", "dom4j");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.dom4j.Dom4jVerifier");

--- a/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/FeaturesDom4jGeneratorTest.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/FeaturesDom4jGeneratorTest.java
@@ -54,8 +54,6 @@ public class FeaturesDom4jGeneratorTest extends AbstractModelloJavaGeneratorTest
         modello.generate(model, "dom4j-writer", parameters);
         modello.generate(model, "dom4j-reader", parameters);
 
-        addDependency("dom4j", "dom4j");
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.dom4j.Dom4jFeaturesVerifier");

--- a/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
@@ -65,10 +65,6 @@ public class JacksonGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "jackson-writer", parameters);
         modello.generate(model, "jackson-reader", parameters);
 
-        addDependency("com.fasterxml.jackson.core", "jackson-core");
-        addDependency("com.fasterxml.jackson.core", "jackson-databind");
-        // looks like jackson-databind requires jackson-annotations to run...
-        addDependency("com.fasterxml.jackson.core", "jackson-annotations");
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
@@ -54,6 +54,6 @@ public class AnnotationsJavaGeneratorTest extends AbstractModelloJavaGeneratorTe
 
         compileGeneratedSources(8);
 
-        verifyCompiledGeneratedSources("AnnotationsVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.AnnotationsVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AnnotationsJavaGeneratorTest.java
@@ -52,8 +52,6 @@ public class AnnotationsJavaGeneratorTest extends AbstractModelloJavaGeneratorTe
 
         modello.generate(model, "java", parameters);
 
-        addDependency("javax.xml.bind", "jaxb-api");
-        addDependency("javax.persistence", "persistence-api");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("AnnotationsVerifier");

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AssociationGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/AssociationGeneratorTest.java
@@ -54,6 +54,6 @@ public class AssociationGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("OneToManyAssociationVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.OneToManyAssociationVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/BiDirectionalOverrideJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/BiDirectionalOverrideJavaGeneratorTest.java
@@ -50,6 +50,6 @@ public class BiDirectionalOverrideJavaGeneratorTest extends AbstractModelloJavaG
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("JavaVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.BidirectionalJavaVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/FeaturesJava5GeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/FeaturesJava5GeneratorTest.java
@@ -54,6 +54,6 @@ public class FeaturesJava5GeneratorTest extends AbstractModelloJavaGeneratorTest
 
         compileGeneratedSources("features", 8);
 
-        verifyCompiledGeneratedSources("JavaVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.FeaturesJavaVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/FeaturesVersionJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/FeaturesVersionJavaGeneratorTest.java
@@ -64,6 +64,6 @@ public class FeaturesVersionJavaGeneratorTest extends AbstractModelloJavaGenerat
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("JavaVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.FeaturesVersionJavaVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/InterfaceAssociationTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/InterfaceAssociationTest.java
@@ -29,6 +29,6 @@ public class InterfaceAssociationTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources(8);
 
-        verifyCompiledGeneratedSources("InterfaceAssociationVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.InterfaceAssociationVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/JavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/JavaGeneratorTest.java
@@ -54,6 +54,6 @@ public class JavaGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("JavaVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.JavaVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/LocationsJavaGeneratorTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/LocationsJavaGeneratorTest.java
@@ -54,6 +54,6 @@ public class LocationsJavaGeneratorTest extends AbstractModelloJavaGeneratorTest
 
         compileGeneratedSources(8);
 
-        verifyCompiledGeneratedSources("JavaLocationsVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.JavaLocationsVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/PackageVersionJavaTest.java
+++ b/modello-plugins/modello-plugin-java/src/test/java/org/codehaus/modello/plugin/java/PackageVersionJavaTest.java
@@ -56,6 +56,6 @@ public class PackageVersionJavaTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources();
 
-        verifyCompiledGeneratedSources("PackageVersionVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.java.PackageVersionVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/annotations/AnnotationsVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/annotations/AnnotationsVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 import java.lang.annotation.Annotation;
 
 /*

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/bidirectional/BidirectionalJavaVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/bidirectional/BidirectionalJavaVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 import org.codehaus.modello.plugin.java.Role;
 import org.codehaus.modello.tests.bidiroverride.BiRole;
 import org.codehaus.modello.verifier.Verifier;
@@ -6,7 +8,7 @@ import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
-public class JavaVerifier
+public class BidirectionalJavaVerifier
     extends Verifier
 {
     public void verify()

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/features-version/FeaturesVersionJavaVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/features-version/FeaturesVersionJavaVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *
@@ -28,7 +30,7 @@ import org.junit.jupiter.api.Assertions;
 /**
  * @author Herve Boutemy
  */
-public class JavaVerifier
+public class FeaturesVersionJavaVerifier
     extends Verifier
 {
     public void verify()

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/features/FeaturesJavaVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/features/FeaturesJavaVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *
@@ -68,7 +70,7 @@ import java.util.Set;
 /**
  * @author Herve Boutemy
  */
-public class JavaVerifier
+public class FeaturesJavaVerifier
     extends Verifier
 {
     public void verify()

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/interfaceAssociationTest/InterfaceAssociationVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/interfaceAssociationTest/InterfaceAssociationVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 import org.junit.jupiter.api.Assertions;
 
 import org.codehaus.modello.ifaceassociation.package1.IPerson;

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/java/JavaVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/java/JavaVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/locations/JavaLocationsVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/locations/JavaLocationsVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/oneToManyAssociation/OneToManyAssociationVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/oneToManyAssociation/OneToManyAssociationVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 import org.codehaus.modello.association.package1.ListSetMapProperties;
 import org.codehaus.modello.association.package1.Person;
 import org.codehaus.modello.association.package2.Location;

--- a/modello-plugins/modello-plugin-java/src/test/verifiers/packageversion/PackageVersionVerifier.java
+++ b/modello-plugins/modello-plugin-java/src/test/verifiers/packageversion/PackageVersionVerifier.java
@@ -1,3 +1,5 @@
+package org.codehaus.modello.generator.java;
+
 /*
  * Copyright (c) 2004, Codehaus.org
  *

--- a/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/FeaturesJDOMGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/FeaturesJDOMGeneratorTest.java
@@ -54,8 +54,6 @@ public class FeaturesJDOMGeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "stax-reader", parameters);
         modello.generate(model, "jdom-writer", parameters);
 
-        addDependency("org.jdom", "jdom");
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.jdom.JDOMFeaturesVerifier");

--- a/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/RootClassnameJDOMGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jdom/src/test/java/org/codehaus/modello/plugin/jdom/RootClassnameJDOMGeneratorTest.java
@@ -55,7 +55,6 @@ public class RootClassnameJDOMGeneratorTest extends AbstractModelloJavaGenerator
         modello.generate(model, "java", parameters);
         modello.generate(model, "jdom-writer", parameters);
 
-        addDependency("org.jdom", "jdom");
         compileGeneratedSources();
 
         // If the code compiles successfully, the test passes

--- a/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
@@ -92,7 +92,6 @@ public class SaxGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "java", parameters);
         modello.generate(model, "sax-writer", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources();
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-snakeyaml/src/test/java/org/codehaus/modello/plugin/snakeyaml/SnakeYamlGeneratorTest.java
+++ b/modello-plugins/modello-plugin-snakeyaml/src/test/java/org/codehaus/modello/plugin/snakeyaml/SnakeYamlGeneratorTest.java
@@ -52,7 +52,6 @@ public class SnakeYamlGeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "snakeyaml-writer", parameters);
         modello.generate(model, "snakeyaml-reader", parameters);
 
-        addDependency("org.yaml", "snakeyaml");
         compileGeneratedSources();
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
@@ -73,9 +73,6 @@ public abstract class AbstractStaxGeneratorTestCase extends AbstractModelloJavaG
             }
         }
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-
         compileGeneratedSources();
 
         verifyCompiledGeneratedSources(className);

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
@@ -60,6 +60,6 @@ public class FeaturesStaxDomGeneratorTest extends AbstractModelloJavaGeneratorTe
         // TODO: see why without this, version system property is set to "2.4.1" value after verify
         System.setProperty("version", getModelloVersion());
 
-        verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.stax.StaxFeaturesVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.stax.StaxFeaturesDomVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
@@ -55,10 +55,6 @@ public class FeaturesStaxDomGeneratorTest extends AbstractModelloJavaGeneratorTe
         modello.generate(model, "stax-writer", parameters);
         modello.generate(model, "stax-reader", parameters);
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-        addDependency("org.xmlunit", "xmlunit-core");
-
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
@@ -54,10 +54,6 @@ public class FeaturesStaxGeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "stax-writer", parameters);
         modello.generate(model, "stax-reader", parameters);
 
-        addDependency("org.codehaus.woodstox", "stax2-api");
-        addDependency("com.fasterxml.woodstox", "woodstox-core");
-        addDependency("org.xmlunit", "xmlunit-core");
-
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-stax/src/test/verifiers/features-dom/StaxFeaturesDomVerifier.java
+++ b/modello-plugins/modello-plugin-stax/src/test/verifiers/features-dom/StaxFeaturesDomVerifier.java
@@ -1,4 +1,4 @@
-package org.codehaus.modello.generator.xml.xpp3;
+package org.codehaus.modello.generator.xml.stax;
 
 /*
  * Copyright (c) 2004, Codehaus.org
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.codehaus.modello.test.features.Features;
-import org.codehaus.modello.test.features.io.xpp3.ModelloFeaturesTestXpp3Reader;
-import org.codehaus.modello.test.features.io.xpp3.ModelloFeaturesTestXpp3Writer;
+import org.codehaus.modello.test.features.io.stax.ModelloFeaturesTestStaxReader;
+import org.codehaus.modello.test.features.io.stax.ModelloFeaturesTestStaxWriter;
 import org.codehaus.modello.verifier.Verifier;
 import org.codehaus.modello.verifier.VerifierException;
 import org.codehaus.plexus.util.FileUtils;
@@ -48,10 +48,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import javax.xml.stream.XMLStreamException;
+
 /**
  * @author Herve Boutemy
  */
-public class Xpp3FeaturesVerifier
+public class StaxFeaturesDomVerifier
     extends Verifier
 {
     public void verify()
@@ -69,8 +71,6 @@ public class Xpp3FeaturesVerifier
 
         verifyWrongElement();
 
-        verifyWrongAttribute();
-
         verifyWrongContent();
 
         verifyTransientElement();
@@ -81,25 +81,25 @@ public class Xpp3FeaturesVerifier
     public void verifyAPI()
         throws Exception
     {
-        assertReader( ModelloFeaturesTestXpp3Reader.class, Features.class, Reader.class, XmlPullParserException.class );
-        assertReader( ModelloFeaturesTestXpp3Reader.class, Features.class, InputStream.class, XmlPullParserException.class );
+        assertReader( ModelloFeaturesTestStaxReader.class, Features.class, Reader.class, XMLStreamException.class );
+        assertReader( ModelloFeaturesTestStaxReader.class, Features.class, InputStream.class, XMLStreamException.class );
 
-        assertWriter( ModelloFeaturesTestXpp3Writer.class, Features.class, Writer.class, XmlPullParserException.class );
-        assertWriter( ModelloFeaturesTestXpp3Writer.class, Features.class, OutputStream.class, XmlPullParserException.class );
+        assertWriter( ModelloFeaturesTestStaxWriter.class, Features.class, Writer.class, XMLStreamException.class );
+        assertWriter( ModelloFeaturesTestStaxWriter.class, Features.class, OutputStream.class, XMLStreamException.class );
     }
 
     public Features verifyReader()
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
-        return reader.read( getClass().getResourceAsStream( "/features.xml" ) );
+        return reader.read( getXmlResourceReader( "/features.xml" ) );
     }
 
     public void verifyWriter( Features features )
         throws Exception
     {
-        ModelloFeaturesTestXpp3Writer writer = new ModelloFeaturesTestXpp3Writer();
+        ModelloFeaturesTestStaxWriter writer = new ModelloFeaturesTestStaxWriter();
 
         StringWriter buffer = new StringWriter();
 
@@ -110,8 +110,8 @@ public class Xpp3FeaturesVerifier
 
         // alias is rendered as default field name => must be reverted here to let the test pass
         actualXml = actualXml.replaceFirst( "<id>alias</id>", "<key>alias</key>" );
-        // writer doesn't check if space has to be preserved, so doesn't add xml:space="preserve" back
-        actualXml = actualXml.replaceFirst( "<preserve>", "<preserve xml:space=\"preserve\">" );
+        // writer doesn't handle namespace
+        actualXml = actualXml.replaceFirst( "<preserve space=\"preserve\">", "<preserve xml:space=\"preserve\">" );
 
         Diff diff = DiffBuilder.compare( initialXml ).withTest( actualXml ).ignoreWhitespace().ignoreComments().build();
 
@@ -146,78 +146,58 @@ public class Xpp3FeaturesVerifier
     public void verifyBadVersion()
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
         try
         {
-            reader.read( getClass().getResourceAsStream( "/features-bad-version.xml" ) );
+            reader.read( getXmlResourceReader( "/features-bad-version.xml" ) );
 
-            //throw new VerifierException( "Reading a document with a version different from the version of the parser should fail." );
-            System.err.print( "[WARNING] missing feature: reading a document with a version different from the version of the parser should fail." );
+            throw new VerifierException( "Reading a document with a version different from the version of the parser should fail." );
         }
-        catch ( XmlPullParserException xppe )
+        catch ( XMLStreamException xse )
         {
-            checkExpectedFailure( xppe, "Document model version of '2.0.0' doesn't match reader version of '1.0.0'" );
+            // expected failure
+            checkExpectedFailure( xse, "Document model version of '2.0.0' doesn't match reader version of '1.0.0'" );
         }
     }
 
     public void verifyWrongElement()
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
         // reading with strict=false should accept unknown element
-        reader.read( getClass().getResourceAsStream( "/features-wrong-element.xml" ), false );
-        reader.read( getClass().getResourceAsStream( "/features-wrong-element2.xml" ), false );
+        reader.read( getXmlResourceReader( "/features-wrong-element.xml" ), false );
+        reader.read( getXmlResourceReader( "/features-wrong-element2.xml" ), false );
 
         // by default, strict=true: reading should not accept unknown element
         try
         {
-            reader.read( getClass().getResourceAsStream( "/features-wrong-element.xml" ) );
+            reader.read( getXmlResourceReader( "/features-wrong-element.xml" ) );
 
             throw new VerifierException( "Reading a document with an unknown element under strict option should fail." );
         }
-        catch ( XmlPullParserException xppe )
+        catch ( XMLStreamException xse )
         {
-            checkExpectedFailure( xppe, "'invalidElement'" );
+            // expected failure
+            checkExpectedFailure( xse, "'invalidElement'" );
         }
         try
         {
-            reader.read( getClass().getResourceAsStream( "/features-wrong-element2.xml" ) );
+            reader.read( getXmlResourceReader( "/features-wrong-element2.xml" ) );
 
             throw new VerifierException( "Reading a document with an unknown element under strict option should fail." );
         }
-        catch ( XmlPullParserException xppe )
+        catch ( XMLStreamException xse )
         {
-            checkExpectedFailure( xppe, "'invalidElement'" );
-        }
-    }
-
-    public void verifyWrongAttribute()
-        throws Exception
-    {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
-
-        // reading with strict=false should accept unknown element
-        reader.read( getClass().getResourceAsStream( "/features-wrong-attribute.xml" ), false );
-
-        // by default, strict=true: reading should not accept unknown attribute
-        try
-        {
-            reader.read( getClass().getResourceAsStream( "/features-wrong-attribute.xml" ) );
-
-            throw new VerifierException( "Reading a document with an unknown attribute under strict option should fail." );
-        }
-        catch ( XmlPullParserException xppe )
-        {
-            checkExpectedFailure( xppe, "Unknown attribute 'invalidAttribute' for tag 'attributes'" );
+            checkExpectedFailure( xse, "'invalidElement'" );
         }
     }
 
     public void verifyWrongContent()
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
         // reading with strict=false should accept unexpected text content
         reader.read( getClass().getResourceAsStream( "/features-wrong-content.xml" ), false );
@@ -229,58 +209,58 @@ public class Xpp3FeaturesVerifier
 
             throw new VerifierException( "Reading a document with a bad content under strict option should fail." );
         }
-        catch ( XmlPullParserException xppe )
+        catch ( XMLStreamException xse )
         {
-            checkExpectedFailure( xppe, "expected START_TAG or END_TAG not TEXT" );
+            checkExpectedFailure( xse, "non-all-whitespace CHARACTERS or CDATA event" );
         }
     }
 
     public void verifyTransientElement()
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
         try
         {
-            reader.read( getClass().getResourceAsStream( "/features-invalid-transient.xml" ) );
+            reader.read( getXmlResourceReader( "/features-invalid-transient.xml" ) );
 
             fail( "Transient fields should not be processed by parser." );
         }
-        catch ( XmlPullParserException e )
+        catch ( XMLStreamException e )
         {
             checkExpectedFailure( e, "transientString" );
         }
     }
 
-    private void checkExpectedFailure( XmlPullParserException xppe, String expectedMessage )
+    private void checkExpectedFailure( XMLStreamException xse, String expectedMessage )
         throws VerifierException
     {
-        if ( xppe.getMessage().indexOf( expectedMessage ) < 0 )
+        if ( xse.getMessage().indexOf( expectedMessage ) < 0 )
         {
-            throw new VerifierException( "Unexpected failure: \"" + xppe.getMessage() + "\"", xppe );
+            throw new VerifierException( "Unexpected failure: \"" + xse.getMessage() + "\"", xse );
         }
     }
 
     private void checkEncoding( String resource, String encoding )
         throws Exception
     {
-        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
 
-        Features features = reader.read( getClass().getResourceAsStream( resource ) );
+        Features features = reader.read( getXmlResourceReader( resource ) );
         assertEquals( encoding, features.getModelEncoding() , "modelEncoding");
 
-        ModelloFeaturesTestXpp3Writer writer = new ModelloFeaturesTestXpp3Writer();
+        ModelloFeaturesTestStaxWriter writer = new ModelloFeaturesTestStaxWriter();
         StringWriter buffer = new StringWriter();
         writer.write( buffer, features );
         String xmlHeader = buffer.toString().substring( 0, 44 );
 
         if ( encoding == null )
         {
-            assertTrue( xmlHeader.startsWith( "<?xml version=\"1.0\"?>" ) , xmlHeader);
+            assertTrue( xmlHeader.startsWith( "<?xml version='1.0'?>" ) , xmlHeader);
         }
         else
         {
-            assertTrue( xmlHeader.startsWith( "<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>" ) , xmlHeader);
+            assertTrue( xmlHeader.startsWith( "<?xml version='1.0' encoding='" + encoding + "'?>" ) , xmlHeader);
         }
     }
 

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
@@ -58,6 +58,6 @@ public class FeaturesXpp3DomGeneratorTest extends AbstractModelloJavaGeneratorTe
 
         compileGeneratedSources(8);
 
-        verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesVerifier");
+        verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesDomVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3DomGeneratorTest.java
@@ -56,7 +56,6 @@ public class FeaturesXpp3DomGeneratorTest extends AbstractModelloJavaGeneratorTe
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesVerifier");

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3GeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/FeaturesXpp3GeneratorTest.java
@@ -54,7 +54,6 @@ public class FeaturesXpp3GeneratorTest extends AbstractModelloJavaGeneratorTest 
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3FeaturesVerifier");

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
@@ -95,7 +95,6 @@ public class Xpp3GeneratorTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
 
-        addDependency("org.xmlunit", "xmlunit-core");
         compileGeneratedSources(8);
 
         // TODO: see why without this, version system property is set to "2.4.1" value after verify

--- a/modello-plugins/modello-plugin-xpp3/src/test/verifiers/features-dom/Xpp3FeaturesDomVerifier.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/verifiers/features-dom/Xpp3FeaturesDomVerifier.java
@@ -1,4 +1,4 @@
-package org.codehaus.modello.generator.xml.stax;
+package org.codehaus.modello.generator.xml.xpp3;
 
 /*
  * Copyright (c) 2004, Codehaus.org
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.codehaus.modello.test.features.Features;
-import org.codehaus.modello.test.features.io.stax.ModelloFeaturesTestStaxReader;
-import org.codehaus.modello.test.features.io.stax.ModelloFeaturesTestStaxWriter;
+import org.codehaus.modello.test.features.io.xpp3.ModelloFeaturesTestXpp3Reader;
+import org.codehaus.modello.test.features.io.xpp3.ModelloFeaturesTestXpp3Writer;
 import org.codehaus.modello.verifier.Verifier;
 import org.codehaus.modello.verifier.VerifierException;
 import org.codehaus.plexus.util.FileUtils;
@@ -48,12 +48,10 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
-import javax.xml.stream.XMLStreamException;
-
 /**
  * @author Herve Boutemy
  */
-public class StaxFeaturesVerifier
+public class Xpp3FeaturesDomVerifier
     extends Verifier
 {
     public void verify()
@@ -71,6 +69,8 @@ public class StaxFeaturesVerifier
 
         verifyWrongElement();
 
+        verifyWrongAttribute();
+
         verifyWrongContent();
 
         verifyTransientElement();
@@ -81,25 +81,25 @@ public class StaxFeaturesVerifier
     public void verifyAPI()
         throws Exception
     {
-        assertReader( ModelloFeaturesTestStaxReader.class, Features.class, Reader.class, XMLStreamException.class );
-        assertReader( ModelloFeaturesTestStaxReader.class, Features.class, InputStream.class, XMLStreamException.class );
+        assertReader( ModelloFeaturesTestXpp3Reader.class, Features.class, Reader.class, XmlPullParserException.class );
+        assertReader( ModelloFeaturesTestXpp3Reader.class, Features.class, InputStream.class, XmlPullParserException.class );
 
-        assertWriter( ModelloFeaturesTestStaxWriter.class, Features.class, Writer.class, XMLStreamException.class );
-        assertWriter( ModelloFeaturesTestStaxWriter.class, Features.class, OutputStream.class, XMLStreamException.class );
+        assertWriter( ModelloFeaturesTestXpp3Writer.class, Features.class, Writer.class, XmlPullParserException.class );
+        assertWriter( ModelloFeaturesTestXpp3Writer.class, Features.class, OutputStream.class, XmlPullParserException.class );
     }
 
     public Features verifyReader()
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
-        return reader.read( getXmlResourceReader( "/features.xml" ) );
+        return reader.read( getClass().getResourceAsStream( "/features.xml" ) );
     }
 
     public void verifyWriter( Features features )
         throws Exception
     {
-        ModelloFeaturesTestStaxWriter writer = new ModelloFeaturesTestStaxWriter();
+        ModelloFeaturesTestXpp3Writer writer = new ModelloFeaturesTestXpp3Writer();
 
         StringWriter buffer = new StringWriter();
 
@@ -110,8 +110,8 @@ public class StaxFeaturesVerifier
 
         // alias is rendered as default field name => must be reverted here to let the test pass
         actualXml = actualXml.replaceFirst( "<id>alias</id>", "<key>alias</key>" );
-        // writer doesn't handle namespace
-        actualXml = actualXml.replaceFirst( "<preserve space=\"preserve\">", "<preserve xml:space=\"preserve\">" );
+        // writer doesn't check if space has to be preserved, so doesn't add xml:space="preserve" back
+        actualXml = actualXml.replaceFirst( "<preserve>", "<preserve xml:space=\"preserve\">" );
 
         Diff diff = DiffBuilder.compare( initialXml ).withTest( actualXml ).ignoreWhitespace().ignoreComments().build();
 
@@ -146,58 +146,78 @@ public class StaxFeaturesVerifier
     public void verifyBadVersion()
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
         try
         {
-            reader.read( getXmlResourceReader( "/features-bad-version.xml" ) );
+            reader.read( getClass().getResourceAsStream( "/features-bad-version.xml" ) );
 
-            throw new VerifierException( "Reading a document with a version different from the version of the parser should fail." );
+            //throw new VerifierException( "Reading a document with a version different from the version of the parser should fail." );
+            System.err.print( "[WARNING] missing feature: reading a document with a version different from the version of the parser should fail." );
         }
-        catch ( XMLStreamException xse )
+        catch ( XmlPullParserException xppe )
         {
-            // expected failure
-            checkExpectedFailure( xse, "Document model version of '2.0.0' doesn't match reader version of '1.0.0'" );
+            checkExpectedFailure( xppe, "Document model version of '2.0.0' doesn't match reader version of '1.0.0'" );
         }
     }
 
     public void verifyWrongElement()
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
         // reading with strict=false should accept unknown element
-        reader.read( getXmlResourceReader( "/features-wrong-element.xml" ), false );
-        reader.read( getXmlResourceReader( "/features-wrong-element2.xml" ), false );
+        reader.read( getClass().getResourceAsStream( "/features-wrong-element.xml" ), false );
+        reader.read( getClass().getResourceAsStream( "/features-wrong-element2.xml" ), false );
 
         // by default, strict=true: reading should not accept unknown element
         try
         {
-            reader.read( getXmlResourceReader( "/features-wrong-element.xml" ) );
+            reader.read( getClass().getResourceAsStream( "/features-wrong-element.xml" ) );
 
             throw new VerifierException( "Reading a document with an unknown element under strict option should fail." );
         }
-        catch ( XMLStreamException xse )
+        catch ( XmlPullParserException xppe )
         {
-            // expected failure
-            checkExpectedFailure( xse, "'invalidElement'" );
+            checkExpectedFailure( xppe, "'invalidElement'" );
         }
         try
         {
-            reader.read( getXmlResourceReader( "/features-wrong-element2.xml" ) );
+            reader.read( getClass().getResourceAsStream( "/features-wrong-element2.xml" ) );
 
             throw new VerifierException( "Reading a document with an unknown element under strict option should fail." );
         }
-        catch ( XMLStreamException xse )
+        catch ( XmlPullParserException xppe )
         {
-            checkExpectedFailure( xse, "'invalidElement'" );
+            checkExpectedFailure( xppe, "'invalidElement'" );
+        }
+    }
+
+    public void verifyWrongAttribute()
+        throws Exception
+    {
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
+
+        // reading with strict=false should accept unknown element
+        reader.read( getClass().getResourceAsStream( "/features-wrong-attribute.xml" ), false );
+
+        // by default, strict=true: reading should not accept unknown attribute
+        try
+        {
+            reader.read( getClass().getResourceAsStream( "/features-wrong-attribute.xml" ) );
+
+            throw new VerifierException( "Reading a document with an unknown attribute under strict option should fail." );
+        }
+        catch ( XmlPullParserException xppe )
+        {
+            checkExpectedFailure( xppe, "Unknown attribute 'invalidAttribute' for tag 'attributes'" );
         }
     }
 
     public void verifyWrongContent()
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
         // reading with strict=false should accept unexpected text content
         reader.read( getClass().getResourceAsStream( "/features-wrong-content.xml" ), false );
@@ -209,58 +229,58 @@ public class StaxFeaturesVerifier
 
             throw new VerifierException( "Reading a document with a bad content under strict option should fail." );
         }
-        catch ( XMLStreamException xse )
+        catch ( XmlPullParserException xppe )
         {
-            checkExpectedFailure( xse, "non-all-whitespace CHARACTERS or CDATA event" );
+            checkExpectedFailure( xppe, "expected START_TAG or END_TAG not TEXT" );
         }
     }
 
     public void verifyTransientElement()
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
         try
         {
-            reader.read( getXmlResourceReader( "/features-invalid-transient.xml" ) );
+            reader.read( getClass().getResourceAsStream( "/features-invalid-transient.xml" ) );
 
             fail( "Transient fields should not be processed by parser." );
         }
-        catch ( XMLStreamException e )
+        catch ( XmlPullParserException e )
         {
             checkExpectedFailure( e, "transientString" );
         }
     }
 
-    private void checkExpectedFailure( XMLStreamException xse, String expectedMessage )
+    private void checkExpectedFailure( XmlPullParserException xppe, String expectedMessage )
         throws VerifierException
     {
-        if ( xse.getMessage().indexOf( expectedMessage ) < 0 )
+        if ( xppe.getMessage().indexOf( expectedMessage ) < 0 )
         {
-            throw new VerifierException( "Unexpected failure: \"" + xse.getMessage() + "\"", xse );
+            throw new VerifierException( "Unexpected failure: \"" + xppe.getMessage() + "\"", xppe );
         }
     }
 
     private void checkEncoding( String resource, String encoding )
         throws Exception
     {
-        ModelloFeaturesTestStaxReader reader = new ModelloFeaturesTestStaxReader();
+        ModelloFeaturesTestXpp3Reader reader = new ModelloFeaturesTestXpp3Reader();
 
-        Features features = reader.read( getXmlResourceReader( resource ) );
+        Features features = reader.read( getClass().getResourceAsStream( resource ) );
         assertEquals( encoding, features.getModelEncoding() , "modelEncoding");
 
-        ModelloFeaturesTestStaxWriter writer = new ModelloFeaturesTestStaxWriter();
+        ModelloFeaturesTestXpp3Writer writer = new ModelloFeaturesTestXpp3Writer();
         StringWriter buffer = new StringWriter();
         writer.write( buffer, features );
         String xmlHeader = buffer.toString().substring( 0, 44 );
 
         if ( encoding == null )
         {
-            assertTrue( xmlHeader.startsWith( "<?xml version='1.0'?>" ) , xmlHeader);
+            assertTrue( xmlHeader.startsWith( "<?xml version=\"1.0\"?>" ) , xmlHeader);
         }
         else
         {
-            assertTrue( xmlHeader.startsWith( "<?xml version='1.0' encoding='" + encoding + "'?>" ) , xmlHeader);
+            assertTrue( xmlHeader.startsWith( "<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>" ) , xmlHeader);
         }
     }
 

--- a/modello-plugins/pom.xml
+++ b/modello-plugins/pom.xml
@@ -61,28 +61,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-test-libs</id>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-              <phase>process-test-resources</phase>
-              <configuration>
-                <outputDirectory>${project.build.directory}/test-libs</outputDirectory>
-                <excludeTransitive>false</excludeTransitive>
-                <stripVersion>true</stripVersion>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/modello-test/pom.xml
+++ b/modello-test/pom.xml
@@ -12,9 +12,7 @@
   <description>Modello Test Package contains the basis to create Modello generator unit-tests, including sample models
     and xml files to test every feature for every plugin.</description>
 
-  <properties>
-    <plexus.compiler.version>2.16.2</plexus.compiler.version>
-  </properties>
+  <properties />
   <dependencies>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
@@ -27,16 +25,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-javac</artifactId>
-      <version>${plexus.compiler.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler-api</artifactId>
-      <version>${plexus.compiler.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
+++ b/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
@@ -22,32 +22,43 @@ package org.codehaus.modello;
  * SOFTWARE.
  */
 
-import javax.inject.Inject;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.codehaus.modello.verifier.VerifierException;
-import org.codehaus.plexus.compiler.Compiler;
-import org.codehaus.plexus.compiler.CompilerConfiguration;
-import org.codehaus.plexus.compiler.CompilerException;
-import org.codehaus.plexus.compiler.CompilerMessage;
-import org.codehaus.plexus.compiler.CompilerResult;
 import org.codehaus.plexus.util.FileUtils;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
 import static org.codehaus.plexus.testing.PlexusExtension.getTestPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,14 +71,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @see org.codehaus.modello.verifier.Verifier Verifier base class for verifiers
  */
 public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGeneratorTest {
-    private List<File> dependencies = new ArrayList<File>();
-
     private List<URL> urls = new ArrayList<URL>();
 
     private List<String> classPathElements = new ArrayList<String>();
-
-    @Inject
-    private Compiler compiler = null; // todo
 
     protected AbstractModelloJavaGeneratorTest(String name) {
         super(name);
@@ -87,29 +93,6 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         return new File(super.getOutputDirectory(), "classes");
     }
 
-    protected void addDependency(String groupId, String artifactId) {
-        File dependencyFile = getDependencyFile(groupId, artifactId);
-
-        dependencies.add(dependencyFile);
-
-        addClassPathFile(dependencyFile);
-    }
-
-    protected File getDependencyFile(String groupId, String artifactId) {
-        // NOTE: dependency version is managed by project POM and not selectable by test
-
-        String libsDir = System.getProperty("tests.lib.dir", "target/test-libs");
-        File dependencyFile = new File(libsDir, artifactId + ".jar");
-
-        assertTrue(dependencyFile.isFile(), "Can't find dependency: " + dependencyFile.getAbsolutePath());
-
-        return dependencyFile;
-    }
-
-    public List<File> getClasspath() {
-        return dependencies;
-    }
-
     protected String getModelloVersion() throws IOException {
         Properties properties = new Properties(System.getProperties());
 
@@ -125,15 +108,15 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         return properties.getProperty("version");
     }
 
-    protected void compileGeneratedSources() throws IOException, CompilerException {
+    protected void compileGeneratedSources() throws IOException {
         compileGeneratedSources(getName(), 8);
     }
 
-    protected void compileGeneratedSources(int minJavaSource) throws IOException, CompilerException {
+    protected void compileGeneratedSources(int minJavaSource) throws IOException {
         compileGeneratedSources(getName(), minJavaSource);
     }
 
-    protected void compileGeneratedSources(String verifierId, int minJavaSource) throws IOException, CompilerException {
+    protected void compileGeneratedSources(String verifierId, int minJavaSource) throws IOException {
         String runtimeVersion = System.getProperty("java.specification.version");
         if (runtimeVersion.startsWith("1.")) {
             runtimeVersion = runtimeVersion.substring(2);
@@ -151,54 +134,122 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         compileGeneratedSources(verifierId, javaSource);
     }
 
-    private void compileGeneratedSources(String verifierId, String javaSource) throws IOException, CompilerException {
+    private void compileGeneratedSources(String verifierId, String javaSource) throws IOException {
         File generatedSources = getOutputDirectory();
         File destinationDirectory = getOutputClasses();
 
-        addDependency("org.junit.jupiter", "junit-jupiter-api");
-        addDependency("org.opentest4j", "opentest4j");
-        addDependency("org.codehaus.plexus", "plexus-utils");
-        addDependency("org.codehaus.plexus", "plexus-xml");
-        // for plexus-xml 4
-        // addDependency("org.apache.maven", "maven-api-xml");
-        // addDependency("org.apache.maven", "maven-xml-impl");
-        addDependency("org.codehaus.modello", "modello-test");
+        List<String> classPath = new ArrayList<>();
+        classPath.add(getTestPath("target/classes"));
+        classPath.add(getTestPath("target/test-classes"));
+        classPath.addAll(resolveTestClasspath());
 
-        String[] classPathElements = new String[dependencies.size() + 2];
-        classPathElements[0] = getTestPath("target/classes");
-        classPathElements[1] = getTestPath("target/test-classes");
-
-        for (int i = 0; i < dependencies.size(); i++) {
-            classPathElements[i + 2] = ((File) dependencies.get(i)).getAbsolutePath();
-        }
-
+        List<File> sourceDirectories = new ArrayList<>();
         File verifierDirectory = getTestFile("src/test/verifiers/" + verifierId);
-        String[] sourceDirectories;
         if (verifierDirectory.canRead()) {
-            sourceDirectories = new String[] {verifierDirectory.getAbsolutePath(), generatedSources.getAbsolutePath()};
-        } else {
-            sourceDirectories = new String[] {generatedSources.getAbsolutePath()};
+            sourceDirectories.add(verifierDirectory);
+        }
+        sourceDirectories.add(generatedSources);
+
+        List<File> sourceFiles = new ArrayList<>();
+        for (File sourceDirectory : sourceDirectories) {
+            sourceFiles.addAll(findJavaSources(sourceDirectory));
         }
 
-        CompilerConfiguration configuration = new CompilerConfiguration();
-        configuration.setClasspathEntries(Arrays.asList(classPathElements));
-        configuration.setSourceLocations(Arrays.asList(sourceDirectories));
-        configuration.setOutputLocation(destinationDirectory.getAbsolutePath());
-        configuration.setDebug(true);
+        // javac up to Java 8 refuses a -d that does not already exist; later versions create it
+        Files.createDirectories(destinationDirectory.toPath());
 
-        configuration.setSourceVersion(javaSource);
-        configuration.setTargetVersion(javaSource);
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(javac, "No java compiler available - the tests need a JDK, not a JRE");
 
-        CompilerResult result = compiler.performCompile(configuration);
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = javac.getStandardFileManager(diagnostics, null, null)) {
+            List<String> options = Arrays.asList(
+                    "-g",
+                    "-classpath",
+                    String.join(File.pathSeparator, classPath),
+                    "-d",
+                    destinationDirectory.getAbsolutePath(),
+                    "-source",
+                    javaSource,
+                    "-target",
+                    javaSource);
 
-        List<CompilerMessage> errors = new ArrayList<CompilerMessage>(0);
-        for (CompilerMessage compilerMessage : result.getCompilerMessages()) {
-            if (compilerMessage.isError()) {
-                errors.add(compilerMessage);
-            }
+            javac.getTask(
+                            null,
+                            fileManager,
+                            diagnostics,
+                            options,
+                            null,
+                            fileManager.getJavaFileObjectsFromFiles(sourceFiles))
+                    .call();
         }
+
+        List<Diagnostic<? extends JavaFileObject>> errors = diagnostics.getDiagnostics().stream()
+                .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                .collect(Collectors.toList());
 
         assertEquals(0, errors.size(), "There was compilation errors: " + errors);
+    }
+
+    private static List<File> findJavaSources(File directory) throws IOException {
+        if (!directory.isDirectory()) {
+            return new ArrayList<>();
+        }
+        try (Stream<Path> paths = Files.walk(directory.toPath())) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Returns this module's test classpath, which is what the verifiers and the generated sources are compiled
+     * against.
+     * <p>
+     * Surefire normally hands the forked JVM a manifest-only "booter" jar rather than a real classpath, so
+     * {@code java.class.path} on its own is a single jar whose {@code Class-Path} manifest entry holds the actual
+     * entries. Expanding that keeps this in step with whatever the POM declares, with no build step to copy jars
+     * around and no second list to maintain here.
+     */
+    private static List<String> resolveTestClasspath() {
+        List<String> classPath = new ArrayList<>();
+        for (String entry : System.getProperty("java.class.path", "").split(File.pathSeparator)) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            classPath.add(entry);
+            // a jar may carry its own Class-Path, so keep both it and whatever it points at
+            classPath.addAll(expandManifestClassPath(new File(entry)));
+        }
+        return classPath;
+    }
+
+    private static List<String> expandManifestClassPath(File jar) {
+        if (!jar.isFile() || !jar.getName().endsWith(".jar")) {
+            return new ArrayList<>();
+        }
+        try (JarFile jarFile = new JarFile(jar)) {
+            Manifest manifest = jarFile.getManifest();
+            if (manifest == null) {
+                return new ArrayList<>();
+            }
+            String classPath = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
+            if (classPath == null || classPath.trim().isEmpty()) {
+                return new ArrayList<>();
+            }
+            List<String> entries = new ArrayList<>();
+            for (String entry : classPath.trim().split("\\s+")) {
+                try {
+                    entries.add(Paths.get(URI.create(entry)).toString());
+                } catch (IllegalArgumentException | java.nio.file.FileSystemNotFoundException e) {
+                    // a relative entry, resolved against the jar itself
+                    entries.add(new File(jar.getParentFile(), entry).getAbsolutePath());
+                }
+            }
+            return entries;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read the manifest of " + jar, e);
+        }
     }
 
     /**
@@ -212,6 +263,14 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         addClassPathFile(getTestFile("target/classes"));
 
         addClassPathFile(getTestFile("target/test-classes"));
+
+        // the verifier runs in a classloader with no parent, so it needs the test classpath spelled out
+        for (String entry : resolveTestClasspath()) {
+            File file = new File(entry);
+            if (file.exists()) {
+                addClassPathFile(file);
+            }
+        }
 
         ClassLoader oldCCL = Thread.currentThread().getContextClassLoader();
         URLClassLoader classLoader = URLClassLoader.newInstance(urls.toArray(new URL[urls.size()]), null);


### PR DESCRIPTION
Stacked on #584 — review that first; the base moves to `master` when it merges.

Ten verifiers sat in the **default package**, and three names were used twice:

- four classes called `JavaVerifier`, under `features/`, `bidirectional/`, `features-version/` and `java/`
- `StaxFeaturesVerifier` under both `features/` and `features-dom/`, in the same package
- `Xpp3FeaturesVerifier`, likewise

That only works because each `verifierId` directory is compiled on its own and loaded through its own classloader with a null parent, so the duplicates never meet. The cost is that `verifyCompiledGeneratedSources("JavaVerifier")` gave no indication which of the four it meant, and the directories could never be looked at together by anything.

The java and converters verifiers move to `org.codehaus.modello.generator.{java,converters}`, matching what dom4j, jackson, sax, stax, jdom and xpp3 already do, and the duplicated names take a prefix naming the model they verify (`FeaturesJavaVerifier`, `BidirectionalJavaVerifier`, `FeaturesVersionJavaVerifier`, `StaxFeaturesDomVerifier`, `Xpp3FeaturesDomVerifier`). Every lookup in the tests now spells out the fully-qualified name.

**What this does not do:** it does not make `src/test/verifiers` compilable at build time. The verifiers assert against classes that do not exist until the generator under test has run — `features/JavaVerifier` alone imports 21 generated types — so the runtime compile stays. The point is narrower: the names no longer rely on the isolation to keep from clashing.

### Verification

`mvn install` with tests: exit 0, 120 tests, zero failures and zero errors across all 14 modules. `spotless:check` clean. Checked separately that no two verifiers share a fully-qualified name any more.

Note on the command: use `install` or `verify`, not `mvn test`. Under `mvn test` this repo reports 5 `NullPointerException`s on any branch including `master`, because `getModelloVersion()` reads a `pom.properties` that maven-archiver only writes at package time — see my comment on #584.

Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)
