### PR TITLE
Let the setUp methods actually run

### DIFF
--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
@@ -32,7 +32,6 @@ import org.codehaus.modello.core.ModelloCore;
 import org.codehaus.modello.model.Model;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.StringUtils;
-import org.junit.jupiter.api.BeforeEach;
 
 @PlexusTest
 public abstract class AbstractStaxGeneratorTestCase extends AbstractModelloJavaGeneratorTest {
@@ -42,11 +41,6 @@ public abstract class AbstractStaxGeneratorTestCase extends AbstractModelloJavaG
 
     protected AbstractStaxGeneratorTestCase(String name) {
         super(name);
-    }
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
     }
 
     protected void verifyModel(Model model, String className) throws Exception {

--- a/modello-test/src/main/java/org/codehaus/modello/AbstractModelloGeneratorTest.java
+++ b/modello-test/src/main/java/org/codehaus/modello/AbstractModelloGeneratorTest.java
@@ -38,6 +38,7 @@ import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.testing.PlexusTestConfiguration;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
+import org.junit.jupiter.api.BeforeEach;
 import org.xml.sax.SAXException;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
@@ -55,6 +56,7 @@ public abstract class AbstractModelloGeneratorTest implements PlexusTestConfigur
         this.name = name;
     }
 
+    @BeforeEach
     public void setUp() throws Exception {
 
         FileUtils.deleteDirectory(getOutputDirectory());

--- a/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
+++ b/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 
 import org.codehaus.modello.verifier.VerifierException;
 import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
 import static org.codehaus.plexus.testing.PlexusExtension.getTestPath;
@@ -79,7 +80,10 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
         super(name);
     }
 
+    @BeforeEach
     public void setUp() throws Exception {
+        super.setUp();
+
         FileUtils.deleteDirectory(getOutputClasses());
 
         assertTrue(getOutputClasses().mkdirs());


### PR DESCRIPTION
Follow-up to #584, where this turned up while debugging a Java 8 failure. It predates that PR and #583 — both methods were already unannotated before either.

Neither `AbstractModelloGeneratorTest.setUp()` nor its override in `AbstractModelloJavaGeneratorTest` carries `@BeforeEach`, so under Jupiter **neither has been called at all**. Both delete and recreate the test's output directory, so `target/generator-results/<name>` is never cleaned between runs and generated classes from an earlier run can survive into a later one and hide a failure. Those directories existed only because the compiler happened to create them — which is exactly how #584 surfaced it, since `javax.tools` on Java 8 will not create a `-d` that is missing.

Annotating is not quite enough on its own. The java override does not call `super`, so the `sources` directory would still go untouched; it now chains, and the two levels clean the two directories they each own.

`AbstractStaxGeneratorTestCase` existed *only* to add `@BeforeEach` and delegate to `super.setUp()` — the workaround for this bug, in the one place someone noticed the symptom. It is removed.

### Evidence that it really was dead

Rather than argue from reading the code, I put an **unconditional** `throw new IllegalStateException` at the top of the base `setUp()` and ran the suite:

| | `modello-plugin-java` | `modello-plugin-xdoc` |
|---|---|---|
| on `master` | 17 tests, **0 errors** | 2 tests, **0 errors** |
| with this change | every test errors | every test errors |

A method that throws unconditionally cannot be executing. The second row also confirms both paths reach it: xdoc extends the base directly, java reaches it through the new `super.setUp()` chain.

### Verification

`mvn install` with tests, every `generator-results` directory deleted first: exit 0, 120 tests, zero failures and zero errors across all 14 modules. `spotless:check` clean.

Use `install` or `verify` rather than `mvn test` here — see my comment on #584 for why `mvn test` reports 5 spurious NPEs on any branch.

Draft until CI confirms, jdk-8 included.

Generated-by: Claude Opus 5 (1M context)
