### PR TITLE
Establish automatic module names

### DIFF
--- a/modello-core/pom.xml
+++ b/modello-core/pom.xml
@@ -64,6 +64,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.6.2</version>
         <executions>

--- a/modello-plugins/modello-plugin-converters/pom.xml
+++ b/modello-plugins/modello-plugin-converters/pom.xml
@@ -42,6 +42,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.converters</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-dom4j/pom.xml
+++ b/modello-plugins/modello-plugin-dom4j/pom.xml
@@ -42,6 +42,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.dom4j</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-jackson/pom.xml
+++ b/modello-plugins/modello-plugin-jackson/pom.xml
@@ -45,6 +45,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.jackson</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-java/pom.xml
+++ b/modello-plugins/modello-plugin-java/pom.xml
@@ -38,6 +38,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.java</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-jdom/pom.xml
+++ b/modello-plugins/modello-plugin-jdom/pom.xml
@@ -48,6 +48,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.jdom</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-jsonschema/pom.xml
+++ b/modello-plugins/modello-plugin-jsonschema/pom.xml
@@ -39,4 +39,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.jsonschema</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modello-plugins/modello-plugin-sax/pom.xml
+++ b/modello-plugins/modello-plugin-sax/pom.xml
@@ -35,6 +35,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.sax</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-snakeyaml/pom.xml
+++ b/modello-plugins/modello-plugin-snakeyaml/pom.xml
@@ -31,6 +31,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.snakeyaml</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-stax/pom.xml
+++ b/modello-plugins/modello-plugin-stax/pom.xml
@@ -49,6 +49,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.stax</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-velocity/pom.xml
+++ b/modello-plugins/modello-plugin-velocity/pom.xml
@@ -26,4 +26,20 @@
       <version>2.4.1</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.velocity</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modello-plugins/modello-plugin-xdoc/pom.xml
+++ b/modello-plugins/modello-plugin-xdoc/pom.xml
@@ -45,6 +45,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.xdoc</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-xml/pom.xml
+++ b/modello-plugins/modello-plugin-xml/pom.xml
@@ -23,4 +23,20 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugins.xml</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modello-plugins/modello-plugin-xpp3/pom.xml
+++ b/modello-plugins/modello-plugin-xpp3/pom.xml
@@ -36,6 +36,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.xpp3</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/modello-plugins/modello-plugin-xsd/pom.xml
+++ b/modello-plugins/modello-plugin-xsd/pom.xml
@@ -35,4 +35,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.plugin.xsd</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modello-test/pom.xml
+++ b/modello-test/pom.xml
@@ -41,4 +41,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.modello.test</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
One per jar module — 16 of them — each the module's top-level package. Set through `maven-jar-plugin` `manifestEntries`, the pattern plexus-utils uses and the rest of this sweep followed; see codehaus-plexus/plexus-xml#92.

Two decisions worth a reviewer's eye:

- **`modello-maven-plugin` is deliberately left out.** A Maven plugin is loaded by classloader and never lands on the module path, so an entry there would be inert.
- **`modello-test` is named `org.codehaus.modello.test`, not after its package.** It and `modello-core` both contain `org.codehaus.modello`. That split package predates this change and a module name cannot fix it — but naming both modules `org.codehaus.modello` would be a hard error the moment the two jars meet on one module path, so the test artifact takes a distinct name.

`modello-plugin-xml` gets `org.codehaus.modello.plugins.xml` — plural, because that is what its package is called.

Verified: every jar built and read back with `jar --describe-module`; all 16 report the intended name, and `modello-maven-plugin` still derives `modello.maven.plugin` from its file name as expected.

*This change was created with AI assistance.*