### PR TITLE
Declare the maven-plugin-tools version locally

### DIFF
--- a/modello-maven-plugin/pom.xml
+++ b/modello-maven-plugin/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>${mavenPluginToolsVersion}</version>
+      <version>${version.maven-plugin-tools}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,8 @@
     <slf4j.version>1.7.36</slf4j.version>
     <sisu.version>1.1.0</sisu.version>
     <mavenVersion>3.6.3</mavenVersion>
+    <!-- declared here rather than inherited, so the build does not depend on what the parent calls it -->
+    <version.maven-plugin-tools>3.15.2</version.maven-plugin-tools>
     <junit4Version>4.13.2</junit4Version>
     <!--
       ! This controls the minimum java version


### PR DESCRIPTION
modello-maven-plugin versions its `maven-plugin-annotations` dependency with the parent's `mavenPluginToolsVersion`. plexus-pom 27 renames every managed version to `version.<artifactId>`, so that property stops existing and the build fails at POM read.

3.15.2 is the value the parent supplies today, so declaring it here keeps the build working under both 26 and 27 and leaves the eventual parent bump a one-line change. The name follows 27's convention, so it can be deleted and re-inherited once the bump lands.

Verified: `mvn clean verify` green across the full reactor on parent 26; `mvn validate` green against a locally installed plexus-pom 27-SNAPSHOT.

*This change was created with AI assistance.*