### PR TITLE
Update parent to plexus 27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>26</version>
+    <version>27</version>
   </parent>
 
   <groupId>org.codehaus.modello</groupId>
@@ -187,8 +187,6 @@
     <slf4j.version>1.7.36</slf4j.version>
     <sisu.version>1.1.0</sisu.version>
     <mavenVersion>3.6.3</mavenVersion>
-    <!-- declared here rather than inherited, so the build does not depend on what the parent calls it -->
-    <version.maven-plugin-tools>3.15.2</version.maven-plugin-tools>
     <junit4Version>4.13.2</junit4Version>
     <!--
       ! This controls the minimum java version


### PR DESCRIPTION
Parent bump, and the property declared in #589 goes with it: 27 supplies `version.maven-plugin-tools`, so modello-maven-plugin inherits it. The reference stays, because maven-plugin-annotations is a dependency and 27 manages no dependencies beyond junit-bom.

Verified: `mvn clean verify` green across the reactor.

*This change was created with AI assistance.*