### PR TITLE
Point the SCM URLs at HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 
   <issueManagement>
     <system>github</system>
-    <url>http://github.com/codehaus-plexus/modello/issues</url>
+    <url>https://github.com/codehaus-plexus/modello/issues</url>
   </issueManagement>
 
   <ciManagement>
@@ -180,7 +180,7 @@
   </distributionManagement>
 
   <properties>
-    <scm.url>scm:git:git@github.com:codehaus-plexus/modello.git</scm.url>
+    <scm.url>scm:git:https://github.com/codehaus-plexus/modello.git</scm.url>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jackson.version>2.22.1</jackson.version>
     <jdom.version>2.0.2</jdom.version>


### PR DESCRIPTION
`connection` is meant to be the anonymous, read-only URL, and both it and `developerConnection` here are
the scp-like SSH form. That makes a release depend on the releaser having an SSH key configured, and gives
anonymous consumers a URL they cannot use.

Every other component in the org uses the HTTPS URL, which works through the git credential helper. Same
change as codehaus-plexus/plexus-sec-dispatcher#142, where the SSH form was not merely inconvenient but
malformed and blocked the release outright.

*This change was created with AI assistance.*