### PR TITLE
Fix site build for issue 593

### DIFF
--- a/modello-maven-plugin/pom.xml
+++ b/modello-maven-plugin/pom.xml
@@ -18,6 +18,12 @@
     <maven>${mavenVersion}</maven>
   </prerequisites>
 
+  <properties>
+    <!-- the features site checked and copied by the reporting profile is produced by the run-its profile,
+         so only enforce its presence when the integration tests were actually requested -->
+    <verifyFeaturesSite>false</verifyFeaturesSite>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.codehaus.modello</groupId>
@@ -172,6 +178,9 @@
   <profiles>
     <profile>
       <id>run-its</id>
+      <properties>
+        <verifyFeaturesSite>true</verifyFeaturesSite>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -221,13 +230,15 @@
             <executions>
               <execution>
                 <id>features</id>
-                <!-- check that run-its profile has generated features site -->
+                <!-- check that the run-its profile has generated the features site, but fail only when
+                     run-its is active: a site build that did not ask for the ITs must not fail here -->
                 <goals>
                   <goal>verify</goal>
                 </goals>
                 <phase>pre-site</phase>
                 <configuration>
                   <verificationFile>${basedir}/src/test/verifier/site-verifications.xml</verificationFile>
+                  <failOnError>${verifyFeaturesSite}</failOnError>
                 </configuration>
               </execution>
             </executions>

--- a/modello-maven-plugin/src/test/verifier/site-verifications.xml
+++ b/modello-maven-plugin/src/test/verifier/site-verifications.xml
@@ -2,7 +2,7 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
   <files>
-    <file><!-- should be available, require mvn run with -Prun-its -->
+    <file><!-- produced by the run-its profile; enforced only when run-its is active, see verifyFeaturesSite -->
       <location>target/it/features/target/site/index.html</location>
     </file>
   </files>

--- a/modello-plugins/modello-plugin-dom4j/src/test/verifiers/dom4j/Dom4jVerifier.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/verifiers/dom4j/Dom4jVerifier.java
@@ -226,10 +226,6 @@ public class Dom4jVerifier
         String actualXml = buffer.toString();
         actualXml = actualXml.replaceAll( "(\r\n)|(\r)", "\n" );
 
-//        System.out.println( expectedXml );
-//
-//        System.err.println( actualXml );
-
         Assertions.assertEquals( expectedXml.trim(), actualXml.trim() );
 
         MavenDom4jReader reader = new MavenDom4jReader();

--- a/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
+++ b/modello-plugins/modello-plugin-jackson/src/test/java/org/codehaus/modello/plugin/jackson/JacksonGeneratorTest.java
@@ -67,9 +67,6 @@ public class JacksonGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources(8);
 
-        // TODO: see why without this, version system property is set to "2.4.1" value after verify
-        System.setProperty("version", getModelloVersion());
-
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.jackson.JacksonVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-sax/src/test/java/org/codehaus/modello/plugin/sax/SaxGeneratorTest.java
@@ -94,9 +94,6 @@ public class SaxGeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources();
 
-        // TODO: see why without this, version system property is set to "2.4.1" value after verify
-        System.setProperty("version", getModelloVersion());
-
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.sax.SaxVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxDomGeneratorTest.java
@@ -57,9 +57,6 @@ public class FeaturesStaxDomGeneratorTest extends AbstractModelloJavaGeneratorTe
 
         compileGeneratedSources(8);
 
-        // TODO: see why without this, version system property is set to "2.4.1" value after verify
-        System.setProperty("version", getModelloVersion());
-
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.stax.StaxFeaturesDomVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/FeaturesStaxGeneratorTest.java
@@ -56,9 +56,6 @@ public class FeaturesStaxGeneratorTest extends AbstractModelloJavaGeneratorTest 
 
         compileGeneratedSources(8);
 
-        // TODO: see why without this, version system property is set to "2.4.1" value after verify
-        System.setProperty("version", getModelloVersion());
-
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.stax.StaxFeaturesVerifier");
     }
 }

--- a/modello-plugins/modello-plugin-stax/src/test/verifiers/stax/StaxVerifier.java
+++ b/modello-plugins/modello-plugin-stax/src/test/verifiers/stax/StaxVerifier.java
@@ -240,10 +240,6 @@ public class StaxVerifier
 
         String actualXml = buffer.toString();
 
-//      System.out.println( expectedXml );
-//
-//        System.out.println( actualXml );
-
         Assertions.assertEquals( cleanLineEndings( expectedXml.trim() ), scrubXmlDeclQuotes( actualXml.trim() ) );
 
         MavenStaxReader reader = new MavenStaxReader();

--- a/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
@@ -130,10 +130,6 @@ public class XdocGeneratorTest extends AbstractModelloGeneratorTest {
         Map<String, Object> parameters = getModelloParameters("4.0.0");
 
         modello.generate(model, "xdoc", parameters);
-
-        // addDependency( "modello", "modello-core", "1.0-SNAPSHOT" );
-
-        // verify( "org.codehaus.modello.generator.xml.cdoc.XdocVerifier", "xdoc" );
         checkInternalLinks("maven.xml");
 
         String content = FileUtils.fileRead(new File(getOutputDirectory(), "maven.xml"), "UTF-8");

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/AbstractElementTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/AbstractElementTest.java
@@ -55,9 +55,5 @@ public class AbstractElementTest extends AbstractModelloJavaGeneratorTest {
         modello.generate(model, "java", parameters);
         modello.generate(model, "xpp3-writer", parameters);
         modello.generate(model, "xpp3-reader", parameters);
-
-        // addDependency( "org.codehaus.modello", "modello-core", getModelloVersion() );
-
-        // compile( generatedSources, classes );
     }
 }

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/Xpp3GeneratorTest.java
@@ -97,9 +97,6 @@ public class Xpp3GeneratorTest extends AbstractModelloJavaGeneratorTest {
 
         compileGeneratedSources(8);
 
-        // TODO: see why without this, version system property is set to "2.4.1" value after verify
-        System.setProperty("version", getModelloVersion());
-
         verifyCompiledGeneratedSources("org.codehaus.modello.generator.xml.xpp3.Xpp3Verifier");
     }
 }

--- a/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/ChangesXsdGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/ChangesXsdGeneratorTest.java
@@ -53,11 +53,6 @@ public class ChangesXsdGeneratorTest extends AbstractModelloGeneratorTest {
 
         modello.generate(model, "xsd", parameters);
 
-        // addDependency( "modello", "modello-core", "1.0-SNAPSHOT" );
-
         // TODO write verifier that compiles generated schema: use jaxp
-
-        // verify( "org.codehaus.modello.generator.xml.xsd.XsdVerifier", "xsd" );
-
     }
 }

--- a/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/XsdGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/XsdGeneratorTest.java
@@ -93,10 +93,6 @@ public class XsdGeneratorTest extends AbstractModelloGeneratorTest {
 
         modello.generate(model, "xsd", parameters);
 
-        // addDependency( "modello", "modello-core", "1.0-SNAPSHOT" );
-
         // TODO write verfier which compile generated schema : use jaxp
-
-        // verify( "org.codehaus.modello.generator.xml.xsd.XsdVerifier", "xsd" );
     }
 }

--- a/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
+++ b/modello-test/src/main/java/org/codehaus/modello/AbstractModelloJavaGeneratorTest.java
@@ -31,7 +31,6 @@ import javax.tools.ToolProvider;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -45,7 +44,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -95,21 +93,6 @@ public abstract class AbstractModelloJavaGeneratorTest extends AbstractModelloGe
 
     protected File getOutputClasses() {
         return new File(super.getOutputDirectory(), "classes");
-    }
-
-    protected String getModelloVersion() throws IOException {
-        Properties properties = new Properties(System.getProperties());
-
-        if (properties.getProperty("version") == null) {
-            InputStream is = this.getClass()
-                    .getResourceAsStream("/META-INF/maven/org.codehaus.modello/modello-test/pom.properties");
-
-            if (is != null) {
-                properties.load(is);
-            }
-        }
-
-        return properties.getProperty("version");
     }
 
     protected void compileGeneratedSources() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
           <plugin>
             <groupId>org.codehaus.modello</groupId>
             <artifactId>modello-maven-plugin</artifactId>
-            <version>2.4.0</version>
+            <version>2.8.0</version>
             <configuration>
               <models>
                 <model>src/main/mdo/modello.mdo</model>


### PR DESCRIPTION
Both halves of #593: the generator tests no longer NPE when the site lifecycle runs in the same reactor invocation, and `-Preporting` alone builds the site instead of failing on integration-test output nobody asked for.

The `version` system property those five tests set has no reader anywhere in the tree — the last one was a commented-out `addDependency` call. Removing the `setProperty` is what fixes the NPE; hardening `getModelloVersion()` would have preserved dead code. That method is gone too, along with the era's other commented-out `addDependency`/`verify`/`compile` leftovers.

`maven-verifier-plugin` 1.1 has no `skip` parameter, so the features-site check is made conditional through `failOnError`, driven by a `verifyFeaturesSite` property that the `run-its` profile flips to `true`. Profile AND-activation and `<activation><file>` were both unusable here — the latter is evaluated before the ITs have run.

Note for release notes: this drops `protected String getModelloVersion()` from `modello-test`, so downstream test code calling it breaks at compile time on upgrade.

Verified: `mvn clean install` → 75 test runs, BUILD SUCCESS
Verified: `mvn -pl modello-maven-plugin -Preporting site` → rc=0; `-Preporting,run-its pre-site` on a clean target → still fails, guard intact

*This change was created with AI assistance.*