### PR TITLE
Stop pinning a version in the README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Modello is a build-time tool, so it goes in `<build><plugins>` rather than in yo
 <plugin>
   <groupId>org.codehaus.modello</groupId>
   <artifactId>modello-maven-plugin</artifactId>
-  <version>2.7.0</version>
   <configuration>
     <version>1.0.0</version>
     <models>


### PR DESCRIPTION
The snippet pinned a version, so it went stale the moment the next release went out — most of these were
advertising the version before the one on Central, and plexus-archiver was offering a 5.0.0 that has never
been released.

Dropping the `<version>` element leaves the Maven Central badge at the top of the page as the single source
of truth, which is where the "Check the badge above for the current version." line was already sending people.

*This change was created with AI assistance.*